### PR TITLE
Ability to specify which fieldtypes are suggested on a per-field basis.

### DIFF
--- a/SeoPro/FieldSuggestions.php
+++ b/SeoPro/FieldSuggestions.php
@@ -6,27 +6,13 @@ use Statamic\API\Fieldset;
 
 class FieldSuggestions
 {
-    protected $allowedTypes = [
-        'text',
-        'textarea',
-        'markdown',
-        'redactor',
-    ];
-
     public function suggestions()
     {
         return collect(Fieldset::all())->flatMap(function ($fieldset) {
             return collect($fieldset->inlinedFields())->map(function ($config, $name) {
                 $type = array_get($config, 'type', 'text');
-
-                if (! in_array($type, $this->allowedTypes)) {
-                    return null;
-                }
-
-                return $name;
+                return ['value' => $name, 'text' => $name, 'type' => $type];
             })->filter();
-        })->sort()->map(function ($name) {
-            return ['value' => $name, 'text' => $name];
-        })->values()->all();
+        })->sortBy('text')->values()->all();
     }
 }

--- a/SeoPro/resources/assets/src/js/SourceFieldtype.vue
+++ b/SeoPro/resources/assets/src/js/SourceFieldtype.vue
@@ -59,7 +59,8 @@ export default {
             customText: null,
             sourceField: null,
             autoBindChangeWatcher: false,
-            changeWatcherWatchDeep: false
+            changeWatcherWatchDeep: false,
+            allowedFieldtypes: []
         }
     },
 
@@ -96,7 +97,7 @@ export default {
         },
 
         suggestSuggestions() {
-            return SeoPro.fieldSuggestions;
+            return SeoPro.fieldSuggestions.filter(item => this.allowedFieldtypes.includes(item.type));
         },
 
         fieldConfig() {
@@ -128,6 +129,9 @@ export default {
     },
 
     ready() {
+        let types = this.config.allowed_fieldtypes || ['text', 'textarea', 'markdown', 'redactor'];
+        this.allowedFieldtypes = types.concat(this.config.merge_allowed_fieldtypes || []);
+
         if (this.data.source === 'field') {
             this.sourceField = [this.data.value];
         } else {

--- a/SeoPro/resources/fieldsets/content.yaml
+++ b/SeoPro/resources/fieldsets/content.yaml
@@ -12,6 +12,8 @@ fields:
           type: text
       image:
         type: seo_pro.source
+        allowed_fieldtypes:
+          - assets
         field:
           type: seo_pro.asset
       priority:

--- a/SeoPro/resources/fieldsets/defaults.yaml
+++ b/SeoPro/resources/fieldsets/defaults.yaml
@@ -33,6 +33,8 @@ sections:
       image:
         type: seo_pro.source
         inherit: false
+        allowed_fieldtypes:
+          - assets
         field:
           type: seo_pro.asset
   twitter:

--- a/SeoPro/resources/fieldsets/sections.yaml
+++ b/SeoPro/resources/fieldsets/sections.yaml
@@ -18,6 +18,8 @@ sections:
         type: section
       image:
         type: seo_pro.source
+        allowed_fieldtypes:
+          - assets
         field:
           type: seo_pro.asset
       sitemap_section:


### PR DESCRIPTION
Currently, in our "from field" selector, you get given a list of all the text-ish fields (text, textarea, markdown, etc), like this:

![image](https://user-images.githubusercontent.com/105211/44432924-17443180-a572-11e8-80b7-f4aaafefc45f.png)

It makes sense for text fields like meta description. Not so much for image fields.

This PR adds support for the internal field to override the fieldtype filter, and we use that on the image fields, like this:

``` yaml
image:
  type: seo_pro.source
  allowed_fieldtypes:
    - assets
```

![image](https://user-images.githubusercontent.com/105211/44432986-77d36e80-a572-11e8-838d-7dc2a13690b7.png)

You can either override it completely like above, or merge in fieldtypes to the initial text ones, like this:

``` yaml
image:
  type: seo_pro.source
  merge_allowed_fieldtypes:
    - assets
```

We don't use that anywhere, though.