### PR TITLE
Generate valid hreflang

### DIFF
--- a/SeoPro/TagData.php
+++ b/SeoPro/TagData.php
@@ -137,7 +137,7 @@ class TagData
             return site_locale();
         }
 
-        return Config::getFullLocale($this->model->locale());
+        return Config::getShortLocale($this->model->locale());
     }
 
     protected function alternateLocales()
@@ -152,7 +152,7 @@ class TagData
 
         return collect($alternates)->map(function ($locale) {
             return [
-                'locale' => Config::getFullLocale($locale),
+                'locale' => Config::getShortLocale($locale),
                 'url' => $this->model->in($locale)->absoluteUrl(),
             ];
         })->all();


### PR DESCRIPTION
The `hreflang` value must always specify a language code. The language code must follow `ISO 639-1` format (e.g. `en`). The full locale (e.g. `en_US`) is not valid.

The `hreflang` value can also include an optional regional code. For example, `en-ie` is for English speakers in Ireland, whereas `es-ie` is for Spanish speakers in Ireland. The region code must follow `ISO 3166-1 alpha-2` format.

This is a quick fix to generate a valid `hreflang` according to `ISO 639-1` format. However, it does not provide a solution for `ISO 3166-1 alpha-2` format.

More here: https://developers.google.com/web/tools/lighthouse/audits/hreflang