### PR TITLE
Add support for multilingual sitemap

### DIFF
--- a/SeoPro/Events/CollectSitemapPagesEvent.php
+++ b/SeoPro/Events/CollectSitemapPagesEvent.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Statamic\Addons\SeoPro\Events;
+
+use Statamic\Data\Content\ContentCollection;
+
+class CollectSitemapPagesEvent
+{
+    /**
+     * @var \Statamic\Data\Content\ContentCollection
+     */
+    private $pages;
+
+    public function __construct(ContentCollection $pages)
+    {
+        $this->pages = $pages;
+    }
+
+    /**
+     * @return \Statamic\Data\Content\ContentCollection
+     */
+    public function getPages()
+    {
+        return $this->pages;
+    }
+
+    /**
+     * @param \Statamic\Data\Content\ContentCollection $pages
+     */
+    public function setPages(ContentCollection $pages)
+    {
+        $this->pages = $pages;
+    }
+}

--- a/SeoPro/Sitemap/Page.php
+++ b/SeoPro/Sitemap/Page.php
@@ -37,4 +37,14 @@ class Page
     {
         return $this->data->get('priority');
     }
+
+    public function locale()
+    {
+        return $this->data->get('locale');
+    }
+
+    public function alternateLocales()
+    {
+        return $this->data->get('alternate_locales');
+    }
 }

--- a/SeoPro/Sitemap/Sitemap.php
+++ b/SeoPro/Sitemap/Sitemap.php
@@ -39,7 +39,7 @@ class Sitemap
 
         // Emit an event to customize the collected pages.
         $collectSitemapPagesEvent = new CollectSitemapPagesEvent($pages);
-        $this->emitEvent('collect_sitemap_pages', $collectSitemapPagesEvent);
+        $this->emitEvent('collectSitemapPages', $collectSitemapPagesEvent);
 
         return $collectSitemapPagesEvent->getPages();
     }

--- a/SeoPro/TagData.php
+++ b/SeoPro/TagData.php
@@ -154,6 +154,8 @@ class TagData
         if (method_exists($this->model, 'lastModified')) {
             return $this->model->lastModified();
         }
+
+        return null;
     }
 
     protected function locale()
@@ -176,11 +178,17 @@ class TagData
         $alternates = array_values(array_diff($this->model->locales(), [$this->model->locale()]));
 
         return collect($alternates)->map(function ($locale) {
+            $localizedModel = $this->model->in($locale);
+            // Only include content if published in the alternate locale.
+            if (!$localizedModel->published()) {
+                return false;
+            }
+
             return [
                 'locale' => Config::getShortLocale($locale),
-                'url' => $this->model->in($locale)->absoluteUrl(),
+                'url' => $localizedModel->absoluteUrl(),
             ];
-        })->all();
+        })->filter()->all();
     }
 
     protected function parseDescriptionField($value)

--- a/SeoPro/resources/views/sitemap.blade.php
+++ b/SeoPro/resources/views/sitemap.blade.php
@@ -1,5 +1,5 @@
 {!! $xmlHeader !!}
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
 
 @foreach ($sitemap->pages() as $page)
     <url>
@@ -7,6 +7,12 @@
         <lastmod>{{ $page->lastmod() }}</lastmod>
         <changefreq>{{ $page->changefreq() }}</changefreq>
         <priority>{{ $page->priority() }}</priority>
+@if (count($page->alternateLocales()))
+        <xhtml:link rel="alternate" hreflang="{{ $page->locale() }}" href="{{ $page->loc() }}"/>
+@foreach ($page->alternateLocales() as $alternate)
+        <xhtml:link rel="alternate" hreflang="{{ $alternate['locale'] }}" href="{{ $alternate['url'] }}"/>
+@endforeach
+@endif
     </url>
 @endforeach
 


### PR DESCRIPTION
### Description

This pull request extends the sitemap to include localized content.

- Each published localized version is represented in its own `<url>` section
- Each `<url>` entry specifies the available alternate languages with the `<xhtml:link>` tag

More information about multilingual sitemaps can be found here: https://support.google.com/webmasters/answer/189077?hl=en

### Example

Here is how the sitemap looks like for a page `about-us` in English, German and French.

```xml
<!-- English version -->
<url>
  <loc>https://mysite.com/about-us</loc>
  <lastmod>2019-09-09</lastmod>
  <changefreq>monthly</changefreq>
  <priority>0.5</priority>
  <xhtml:link rel="alternate" hreflang="en" href="https://mysite.com/about-us" />
  <xhtml:link rel="alternate" hreflang="de" href="https://mysite.com/de/ueber-uns" />
  <xhtml:link rel="alternate" hreflang="fr" href="https://mysite.com/fr/a-propos-de-nous"/>
</url>

<!-- German version -->
<url>
  <loc>https://mysite.com/de/ueber-uns</loc>
  <lastmod>2019-09-09</lastmod>
  <changefreq>monthly</changefreq>
  <priority>0.5</priority>
  <xhtml:link rel="alternate" hreflang="de" href="https://mysite.com/de/ueber-uns" />
  <xhtml:link rel="alternate" hreflang="en" href="https://mysite.com/about-us" />
  <xhtml:link rel="alternate" hreflang="fr" href="https://mysite.com/fr/a-propos-de-nous"/>
</url>

<!-- French version -->
<url>
  <loc>https://mysite.com/fr/a-propos-de-nous</loc>
  <lastmod>2019-09-09</lastmod>
  <changefreq>monthly</changefreq>
  <priority>0.5</priority>
  <xhtml:link rel="alternate" hreflang="fr" href="https://mysite.com/fr/a-propos-de-nous" />
  <xhtml:link rel="alternate" hreflang="en" href="https://mysite.com/about-us" />
  <xhtml:link rel="alternate" hreflang="de" href="https://mysite.com/de/ueber-uns"/>
</url>
```

### Additional Changes

* The `TagData:: alternateLocales()` only returns alternates of published content. This check is currently not performed, resulting in links to unpublished content (404) when rendering the meta tags.
* A new event `SeoPro.collectSitemapPages` is emitted after the sitemap pages have been collected. This allows addons to modify the pages before rendering the sitemap. One example is to include pages of custom routes.

Related Issues: #56  #50 
