### PR TITLE
Update Listing.vue

### DIFF
--- a/resources/js/components/reporting/Listing.vue
+++ b/resources/js/components/reporting/Listing.vue
@@ -8,7 +8,7 @@
                         <td class="w-1 text-center">
                             <status-icon :status="report.status"></status-icon>
                         </td>
-                        <td class="text-xs w-16"
+                        <td class="text-xs w-16 whitespace-no-wrap"
                             :class="{
                                 'text-red': report.score < 70,
                                 'text-yellow-dark': report.score > 70 && report.score < 90,


### PR DESCRIPTION
Prevent % from wrapping to the next line. (Saw this happening on Safari with 100%)

Before:
<img width="925" alt="image" src="https://user-images.githubusercontent.com/1778271/89772870-c4524480-dad0-11ea-9cdf-5d6888d8ceaf.png">

After:
<img width="930" alt="image" src="https://user-images.githubusercontent.com/1778271/89772897-d6cc7e00-dad0-11ea-8d32-f5a19e9f3b08.png">
