### PR TITLE
Fix `parse_url()` path error on home page in Rules\ThreeSegmentUrls

### DIFF
--- a/src/Reporting/Rules/ThreeSegmentUrls.php
+++ b/src/Reporting/Rules/ThreeSegmentUrls.php
@@ -27,7 +27,7 @@ class ThreeSegmentUrls extends Rule
 
     public function processPage()
     {
-        $url = parse_url($this->page->url())['path'];
+        $url = parse_url($this->page->url())['path'] ?? '/';
         $this->slashes = substr_count($url, '/');
     }
 


### PR DESCRIPTION
The report queue fails as soon as it gets to the home page. This is caused by the missing path index.

Same fix as abd1697cfbc38c09f285211a424ae2a437a065f3 for similar bug #111 .