### PR TITLE
Filter out pages without a uri

### DIFF
--- a/src/Reporting/Report.php
+++ b/src/Reporting/Report.php
@@ -115,7 +115,7 @@ class Report implements Arrayable, Jsonable
     {
         return $this->allContent()
             ->map(function ($content) {
-                if ($content->value('seo') === false) {
+                if ($content->value('seo') === false || is_null($content->uri())) {
                     return;
                 }
 

--- a/src/Sitemap/Sitemap.php
+++ b/src/Sitemap/Sitemap.php
@@ -62,6 +62,9 @@ class Sitemap
             })
             ->filter(function ($entry) {
                 return $entry->status() === 'published';
+            })
+            ->reject(function ($entry) {
+                return is_null($entry->uri());
             });
     }
 


### PR DESCRIPTION
SEO Pro currently makes the assumption that all collection entries are public facing on their own URI. However, myself and others [[1](https://github.com/statamic/ssg/issues/27#issuecomment-680403433)][[2](https://github.com/statamic/ssg/issues/26#issue-685072672)] use collections that do not have routes. 

Borrowing from my solution in [statamic/ssg](https://github.com/statamic/ssg/pull/30) this fixes the bugs where entries without routes are shown in the sitemap.xml and in the seo report.

This does not handle hiding the SEO section from Blueprint or the Collection entries themselves. I wasn't able to figure this out. I was able to hide the SEO tab from the collection entries by adding the following to `Blueprint.addSeoFields()`, but unable to hide the SEO section in the Blueprint view. However, it may be beneficial to keep these in place if these collections ever are upgraded to public facing entries. Wouldn't make sense for the report/sitemap; but could for these fields.
```
        if ($this->data instanceof Entry && is_null($this->data->uri())) {
            return;
        }
```

This does make me wonder if there should be a more wholistic approach to routeless collections. Or maybe checking if the entry has a URI is exactly the correct approach.

Before:
![image](https://user-images.githubusercontent.com/692663/94332218-f556dd80-ff87-11ea-8ce4-6b9274df5795.png)

After:
![image](https://user-images.githubusercontent.com/692663/94332200-c80a2f80-ff87-11ea-91d9-385b656cb1d5.png)