### PR TITLE
Update twitter cards to use large images by default

### DIFF
--- a/resources/views/meta.antlers.html
+++ b/resources/views/meta.antlers.html
@@ -32,7 +32,7 @@
     <meta property="og:locale:alternate" content="{{ locale }}" />
 {{ /alternate_locales }}
 
-<meta name="twitter:card" content="summary" />
+<meta name="twitter:card" content="summary_large_image" />
 
 {{ if twitter_handle }}
     <meta name="twitter:site" content="{{ twitter_handle | trim | ensure_left:@ }}" />


### PR DESCRIPTION
Large summary cards are better. Of course, it would be cool if this view could be published and overwritten.