### PR TITLE
Allow alternative_locales to be disabled in config

### DIFF
--- a/config/seo-pro.php
+++ b/config/seo-pro.php
@@ -34,4 +34,7 @@ return [
         'card' => 'summary_large_image',
     ],
 
+    'alternate_locales' => [
+        'enabled_in_meta' => true,
+    ],
 ];

--- a/resources/views/meta.antlers.html
+++ b/resources/views/meta.antlers.html
@@ -28,9 +28,11 @@
 
 <meta property="og:locale" content="{{ locale }}" />
 
-{{ alternate_locales }}
-    <meta property="og:locale:alternate" content="{{ locale }}" />
-{{ /alternate_locales }}
+{{ if alternate_locales }}
+    {{ alternate_locales }}
+        <meta property="og:locale:alternate" content="{{ locale }}" />
+    {{ /alternate_locales }}
+{{ /if }}
 
 <meta name="twitter:card" content="{{ twitter_card }}" />
 

--- a/src/Cascade.php
+++ b/src/Cascade.php
@@ -265,6 +265,10 @@ class Cascade
 
     protected function alternateLocales()
     {
+        if (! config('statamic.seo-pro.alternate_locales.enabled_in_meta')) {
+            return [];
+        }
+
         if (! $this->model) {
             return [];
         }


### PR DESCRIPTION
This allows alternate_locales to be disabled for meta tag generation.
This might be useful for people that are using the Multi-Site system for purposes other than alternate locales such as a different brand (think tenancy-like usage). 

Even the docs mention this as a valid use-case for the multi-site system: https://statamic.dev/multi-site#overview

Happy to adjust the PR as needed :)

Maybe @jesseleite can take a look? 