### PR TITLE
Add title to <title> tag on Section Defaults page

### DIFF
--- a/resources/views/sections.blade.php
+++ b/resources/views/sections.blade.php
@@ -1,4 +1,5 @@
 @extends('statamic::layout')
+@section('title', __('seo-pro::messages.section_defaults'))
 
 @section('content')
 


### PR DESCRIPTION
The `<title>` tag on the Section Defaults page (`/cp/seo-pro/section-defaults`) was defaulting to this: 

```
<title>Here ‹ Statamic</title>
```

This change adds the proper title pulled from the messages.php file.