### PR TITLE
Fix `method_exists` on null model exceptions in `Cascade`

### DIFF
--- a/src/Cascade.php
+++ b/src/Cascade.php
@@ -23,6 +23,8 @@ class Cascade
     public function __construct()
     {
         $this->data = collect();
+
+        $this->model = new NullModel;
     }
 
     public function forSitemap()

--- a/src/Cascade.php
+++ b/src/Cascade.php
@@ -48,7 +48,8 @@ class Cascade
         }
 
         $this->current = $this->augmentData($data);
-        $this->model = $data;
+
+        $this->model = $data ?? new NullModel;
 
         return $this;
     }

--- a/src/NullModel.php
+++ b/src/NullModel.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Statamic\SeoPro;
+
+class NullModel
+{
+    public function __call($method, $args)
+    {
+        //
+    }
+}

--- a/tests/CascadeTest.php
+++ b/tests/CascadeTest.php
@@ -113,4 +113,37 @@ class CascadeTest extends TestCase
 
         $this->assertEquals('Red', $data['description']);
     }
+
+    /** @test */
+    public function it_generates_seo_cascade_without_exception_when_no_home_entry_exists()
+    {
+        Entry::findByUri('/')->delete();
+
+        $data = (new Cascade)
+            ->with(SiteDefaults::load()->all())
+            ->get();
+
+        $expected = [
+            'site_name' => 'Site Name',
+            'site_name_position' => 'after',
+            'site_name_separator' => '|',
+            'title' => null,
+            'description' => null,
+            'priority' => 0.5,
+            'change_frequency' => 'monthly',
+            'compiled_title' => 'Site Name',
+            'og_title' => 'Site Name',
+            'canonical_url' => '',
+            'prev_url' => null,
+            'next_url' => null,
+            'home_url' => 'http://cool-runnings.com/',
+            'humans_txt' => 'http://cool-runnings.com/humans.txt',
+            'locale' => 'default',
+            'alternate_locales' => [],
+            'last_modified' => null,
+            'twitter_card' => 'summary_large_image',
+        ];
+
+        $this->assertEquals($expected, $data);
+    }
 }


### PR DESCRIPTION
Fix `method_exists()` on null model exceptions in `Cascade` when home page doesn't exist.

Closes #185.