### PR TITLE
Fix tests

### DIFF
--- a/src/Cascade.php
+++ b/src/Cascade.php
@@ -302,7 +302,7 @@ class Cascade
             return null;
         }
 
-        $value = strip_tags($value);
+        $value = trim(strip_tags($value));
 
         if (strlen($value) > 320) {
             $value = substr($value, 0, 320).'...';

--- a/tests/Fixtures/content/collections/pages/home.md
+++ b/tests/Fixtures/content/collections/pages/home.md
@@ -1,7 +1,6 @@
 ---
 title: Home
 template: home
-blueprint: home
 subtitle: 'I see pride. I see power.'
 updated_by: b6c037ad-5bcc-41a8-a455-9ab54573f689
 updated_at: 1606223924

--- a/tests/MetaTagTest.php
+++ b/tests/MetaTagTest.php
@@ -35,7 +35,7 @@ class MetaTagTest extends TestCase
 <meta property="og:description" content="I see a bad-ass mother." />
 <meta property="og:url" content="http://cool-runnings.com" />
 <meta property="og:site_name" content="Site Name" />
-<meta property="og:locale" content="default" />
+<meta property="og:locale" content="en" />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="Home" />
 <meta name="twitter:description" content="I see a bad-ass mother." />

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -77,7 +77,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         $app->make(Manifest::class)->manifest = [
             'statamic/seo-pro' => [
                 'id' => 'statamic/seo-pro',
-                'namespace' => 'Statamic\\SeoPro\\',
+                'namespace' => 'Statamic\\SeoPro',
             ],
         ];
     }


### PR DESCRIPTION
When tagging a version that supported 2.3.0, tests broke because of some changes in Statamic 3.2.

The addon itself seems fine, but it looks like it's just some test-specific things that need tweaking.