### PR TITLE
Allow specifying site defaults path in config

### DIFF
--- a/config/seo-pro.php
+++ b/config/seo-pro.php
@@ -39,4 +39,5 @@ return [
         'excluded_sites' => [],
     ],
 
+    'site_defaults_path' => base_path('content/seo.yaml'),
 ];

--- a/src/SiteDefaults.php
+++ b/src/SiteDefaults.php
@@ -92,7 +92,7 @@ class SiteDefaults extends Collection
      */
     protected function path()
     {
-        return base_path('content/seo.yaml');
+        return config('statamic.seo-pro.site_defaults_path');
     }
 
     /**


### PR DESCRIPTION
We've taken a slightly non-standard approach to multisite as the standard way didn't really work for one of our current projects. But not being able to set the path for this is stopping us from having separate SEO defaults in each locale.