### PR TITLE
Fix rare `fieldtype() on null` error, preventing the ability to save an entry

### DIFF
--- a/src/Fieldtypes/SourceFieldtype.php
+++ b/src/Fieldtypes/SourceFieldtype.php
@@ -36,6 +36,13 @@ class SourceFieldtype extends Fieldtype
             return ['source' => 'inherit', 'value' => $data];
         }
 
+        // Handle issue with legacy `sitemap: true` section default.
+        // This shouldn't ever be explicitly set `true` in Statamic v3,
+        // but it may be migrated as `true` when coming from Statamic v2.
+        if ($this->field->handle() === 'sitemap' && $originalData === true) {
+            return ['source' => 'inherit', 'value' => null];
+        }
+
         return ['source' => 'custom', 'value' => $data];
     }
 


### PR DESCRIPTION
If you've migrated a Statamic v2 site, you may have `sitemap: true` set in a collection's section defaults. This causes errors on the section defaults form, and also a `Call to a member function fieldtype() on null` error that prevents the ability to save an entry.

Though we could have originally addressed this in statamic/migrator, this PR fixes the issue for all users (including those who have already migrated from v2) by normalizing the sitemap's field value here in the addon.

Closes #238.