### PR TITLE
Fix `Value` instance type error when merging non-existent `seo` data

### DIFF
--- a/src/Reporting/Report.php
+++ b/src/Reporting/Report.php
@@ -122,7 +122,7 @@ class Report implements Arrayable, Jsonable
                 $data = (new Cascade)
                     ->with(SiteDefaults::load()->augmented())
                     ->with($this->getAugmentedSectionDefaults($content))
-                    ->with($content->augmentedValue('seo'))
+                    ->with($content->augmentedValue('seo')->value())
                     ->withCurrent($content)
                     ->get();
 


### PR DESCRIPTION
Fix `Value` instance type error (see https://github.com/statamic/seo-pro/issues/245#issuecomment-1348367004), when merging non-existent entry `seo` data.

Fixes #245.