### PR TITLE
Fix paginated urls with custom routing (ie. when using SSG)

### DIFF
--- a/src/Cascade.php
+++ b/src/Cascade.php
@@ -132,6 +132,8 @@ class Cascade
             return $url;
         }
 
+        $paginator->setPath($url);
+
         $page = $paginator->currentPage();
 
         switch (true) {

--- a/tests/MetaTagTest.php
+++ b/tests/MetaTagTest.php
@@ -767,8 +767,10 @@ EOT;
 
     protected function simulatePageOutOfFive($currentPage)
     {
-        Blink::put('tag-paginator', new LengthAwarePaginator([], 15, 3, $currentPage));
+        $url = '/about';
 
-        return $this->call('GET', '/about', ['page' => $currentPage]);
+        Blink::put('tag-paginator', (new LengthAwarePaginator([], 15, 3, $currentPage))->setPath($url));
+
+        return $this->call('GET', $url, ['page' => $currentPage]);
     }
 }

--- a/tests/MetaTagTest.php
+++ b/tests/MetaTagTest.php
@@ -5,6 +5,7 @@ namespace Tests;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Route;
+use Statamic\Extensions\Pagination\LengthAwarePaginator as StatamicLengthAwarePaginator;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Config;
@@ -598,6 +599,25 @@ EOT;
      * @test
      *
      * @dataProvider viewScenarioProvider
+     *
+     * @environment-setup useFakeSsgPaginator
+     */
+    public function it_applies_custom_pagination_routing_to_meta_urls($viewType)
+    {
+        $this->withoutExceptionHandling();
+        $this->prepareViews($viewType);
+
+        $response = $this->simulatePageOutOfFive(3, FakeSsgPaginator::class);
+        $response->assertSee("<h1>{$viewType}</h1>", false);
+        $response->assertSee('<link href="http://cool-runnings.com/about/page/3" rel="canonical" />', false);
+        $response->assertSee('<link href="http://cool-runnings.com/about/page/2" rel="prev" />', false);
+        $response->assertSee('<link href="http://cool-runnings.com/about/page/4" rel="next" />', false);
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider viewScenarioProvider
      */
     public function it_generates_robots_meta($viewType)
     {
@@ -765,12 +785,22 @@ EOT;
         ]);
     }
 
-    protected function simulatePageOutOfFive($currentPage)
+    protected function simulatePageOutOfFive($currentPage, $customPaginatorClass = null)
     {
         $url = '/about';
 
-        Blink::put('tag-paginator', (new LengthAwarePaginator([], 15, 3, $currentPage))->setPath($url));
+        $paginatorClass = $customPaginatorClass ?? LengthAwarePaginator::class;
+
+        Blink::put('tag-paginator', (new $paginatorClass([], 15, 3, $currentPage))->setPath($url));
 
         return $this->call('GET', $url, ['page' => $currentPage]);
+    }
+}
+
+class FakeSsgPaginator extends StatamicLengthAwarePaginator
+{
+    public function url($page)
+    {
+        return \Statamic\Facades\URL::makeRelative(sprintf('%s/page/%s', $this->path(), $page));
     }
 }


### PR DESCRIPTION
A customer reported via email that when using statamic/seo-pro with statamic/ssg, Seo Pro doesn't output the proper pagination links in the meta (ie. a statically generated site will have custom pagination routing that uses a configurable `/articles/page/2` style convention, instead of the typical `/articles?page=2` get parameters). This PR uses the blinked paginator to generate SSG-friendly URLs when generating SEO meta for static pages.