### PR TITLE
Misc nav improvements

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -111,7 +111,6 @@ class ServiceProvider extends AddonServiceProvider
                 $nav->tools('SEO Pro')
                     ->route('seo-pro.index')
                     ->icon('seo-search-graph')
-                    ->active('seo-pro')
                     ->children(function () use ($nav) {
                         return [
                             $nav->item(__('seo-pro::messages.reports'))->route('seo-pro.reports.index')->can('view seo reports'),

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -112,11 +112,13 @@ class ServiceProvider extends AddonServiceProvider
                     ->route('seo-pro.index')
                     ->icon('seo-search-graph')
                     ->active('seo-pro')
-                    ->children([
-                        $nav->item(__('seo-pro::messages.reports'))->route('seo-pro.reports.index')->can('view seo reports'),
-                        $nav->item(__('seo-pro::messages.site_defaults'))->route('seo-pro.site-defaults.edit')->can('edit seo site defaults'),
-                        $nav->item(__('seo-pro::messages.section_defaults'))->route('seo-pro.section-defaults.index')->can('edit seo section defaults'),
-                    ]);
+                    ->children(function () use ($nav) {
+                        return [
+                            $nav->item(__('seo-pro::messages.reports'))->route('seo-pro.reports.index')->can('view seo reports'),
+                            $nav->item(__('seo-pro::messages.site_defaults'))->route('seo-pro.site-defaults.edit')->can('edit seo site defaults'),
+                            $nav->item(__('seo-pro::messages.section_defaults'))->route('seo-pro.section-defaults.index')->can('edit seo section defaults'),
+                        ];
+                    });
             }
         });
 


### PR DESCRIPTION
- [x] Use closure to prevent unessessary permissions checks on irrelevant URLs.
- [x] Remove explicit active pattern.
  - It was never needed because nested SEO Pro URLs have sensible hierarchical structure...
  - ie) All SEO Pro URLs are nested within `/cp/seo-pro` 👌 
     - SEO Pro -> /cp/seo-pro
     - Section Defaults -> /cp/seo-pro/section-defaults
     - Articles Defaults -> /cp/seo-pro/section-defaults/collections/articles/edit