### PR TITLE
Container-ize `SiteDefaults`

### DIFF
--- a/src/Fields.php
+++ b/src/Fields.php
@@ -241,7 +241,7 @@ class Fields
      */
     protected function getPlaceholder($handle)
     {
-        $cascade = (new Cascade)->with(SiteDefaults::load()->all());
+        $cascade = (new Cascade)->with(app(SiteDefaults::class)::load()->all());
 
         if ($this->data) {
             $cascade = $cascade

--- a/src/Http/Controllers/HumansController.php
+++ b/src/Http/Controllers/HumansController.php
@@ -13,7 +13,7 @@ class HumansController extends Controller
         abort_unless(config('statamic.seo-pro.humans.enabled'), 404);
 
         $cascade = (new Cascade)
-            ->with(SiteDefaults::load()->all())
+            ->with(app(SiteDefaults::class)::load()->all())
             ->get();
 
         $contents = view('seo-pro::humans', $cascade);

--- a/src/Http/Controllers/SiteDefaultsController.php
+++ b/src/Http/Controllers/SiteDefaultsController.php
@@ -14,11 +14,11 @@ class SiteDefaultsController extends CpController
     {
         abort_unless(User::current()->can('edit seo site defaults'), 403);
 
-        $blueprint = SiteDefaults::blueprint();
+        $blueprint = app(SiteDefaults::class)::blueprint();
 
         $fields = $blueprint
             ->fields()
-            ->addValues(SiteDefaults::load()->all())
+            ->addValues(app(SiteDefaults::class)::load()->all())
             ->preProcess();
 
         return view('seo-pro::edit', [
@@ -34,7 +34,7 @@ class SiteDefaultsController extends CpController
     {
         abort_unless(User::current()->can('edit seo site defaults'), 403);
 
-        $blueprint = SiteDefaults::blueprint();
+        $blueprint = app(SiteDefaults::class)::blueprint();
 
         $fields = $blueprint->fields()->addValues($request->all());
 
@@ -42,6 +42,6 @@ class SiteDefaultsController extends CpController
 
         $values = Arr::removeNullValues($fields->process()->values()->all());
 
-        SiteDefaults::load($values)->save();
+        app(SiteDefaults::class)::load($values)->save();
     }
 }

--- a/src/Reporting/Report.php
+++ b/src/Reporting/Report.php
@@ -120,7 +120,7 @@ class Report implements Arrayable, Jsonable
                 }
 
                 $data = (new Cascade)
-                    ->with(SiteDefaults::load()->augmented())
+                    ->with(app(SiteDefaults::class)::load()->augmented())
                     ->with($this->getAugmentedSectionDefaults($content))
                     ->with($content->augmentedValue('seo')->value())
                     ->withCurrent($content)
@@ -336,7 +336,7 @@ class Report implements Arrayable, Jsonable
     public function defaults()
     {
         return collect((new Cascade)
-            ->with(SiteDefaults::load()->all())
+            ->with(app(SiteDefaults::class)::load()->all())
             ->get());
     }
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -48,6 +48,7 @@ class ServiceProvider extends AddonServiceProvider
     {
         $this
             ->bootAddonConfig()
+            ->bootAddonBindings()
             ->bootAddonViews()
             ->bootAddonBladeDirective()
             ->bootAddonPermissions()
@@ -170,7 +171,7 @@ class ServiceProvider extends AddonServiceProvider
                 'type' => GraphQL::type('SeoPro'),
                 'resolve' => function ($item) {
                     return (new Cascade)
-                        ->with(SiteDefaults::load()->augmented())
+                        ->with(app(SiteDefaults::class)::load()->augmented())
                         ->with($this->getAugmentedSectionDefaults($item))
                         ->with($item->seo)
                         ->withCurrent($item)
@@ -181,6 +182,13 @@ class ServiceProvider extends AddonServiceProvider
 
         GraphQL::addField('EntryInterface', 'seo', $seoField);
         GraphQL::addField('TermInterface', 'seo', $seoField);
+
+        return $this;
+    }
+    
+    protected function bootAddonBindings()
+    {
+        $this->app->singleton(SiteDefaults::class, SiteDefaults::class);
 
         return $this;
     }

--- a/src/Sitemap/Sitemap.php
+++ b/src/Sitemap/Sitemap.php
@@ -108,7 +108,7 @@ class Sitemap
     protected function getSiteDefaults()
     {
         return Blink::once('seo-pro.site-defaults', function () {
-            return SiteDefaults::load()->all();
+            return app(SiteDefaults::class)::load()->all();
         });
     }
 }

--- a/src/Tags/SeoProTags.php
+++ b/src/Tags/SeoProTags.php
@@ -39,7 +39,7 @@ class SeoProTags extends Tags
         $current = optional($this->context->get('seo'))->augmentable();
 
         $metaData = (new Cascade)
-            ->with(SiteDefaults::load()->augmented())
+            ->with(app(SiteDefaults::class)::load()->augmented())
             ->with($this->getAugmentedSectionDefaults($current))
             ->with($this->context->value('seo'))
             ->with($current ? [] : $this->context->except('template_content'))


### PR DESCRIPTION
As discussed on Discord this PR container-izes SiteDefaults, allowing developers to override its methods, eg

```php
            $this->app->bind(\Statamic\SeoPro\SiteDefaults::class, \App\MySiteDefaults::class);
```

My use case is storing the data in a database rather than a flat file by overloading the save and getDefaults methods.

