### PR TITLE
Allow for swappable `SiteDefaults` implementation

### DIFF
--- a/src/Http/Controllers/SiteDefaultsController.php
+++ b/src/Http/Controllers/SiteDefaultsController.php
@@ -14,11 +14,13 @@ class SiteDefaultsController extends CpController
     {
         abort_unless(User::current()->can('edit seo site defaults'), 403);
 
-        $blueprint = SiteDefaults::blueprint();
+        $siteDefaults = SiteDefaults::load();
+
+        $blueprint = $siteDefaults->blueprint();
 
         $fields = $blueprint
             ->fields()
-            ->addValues(SiteDefaults::load()->all())
+            ->addValues($siteDefaults->all())
             ->preProcess();
 
         return view('seo-pro::edit', [
@@ -34,7 +36,7 @@ class SiteDefaultsController extends CpController
     {
         abort_unless(User::current()->can('edit seo site defaults'), 403);
 
-        $blueprint = SiteDefaults::blueprint();
+        $blueprint = SiteDefaults::load()->blueprint();
 
         $fields = $blueprint->fields()->addValues($request->all());
 

--- a/src/SiteDefaults.php
+++ b/src/SiteDefaults.php
@@ -53,7 +53,7 @@ class SiteDefaults extends Collection
             ->augment()
             ->values();
 
-        $defaultValues = static::blueprint()
+        $defaultValues = $this->blueprint()
             ->fields()
             ->addValues($this->items)
             ->augment()
@@ -102,7 +102,7 @@ class SiteDefaults extends Collection
      *
      * @return \Statamic\Fields\Blueprint
      */
-    public static function blueprint()
+    public function blueprint()
     {
         return Blueprint::make()->setContents([
             'sections' => [

--- a/src/SiteDefaults.php
+++ b/src/SiteDefaults.php
@@ -34,7 +34,9 @@ class SiteDefaults extends Collection
      */
     public static function load($items = null)
     {
-        return new static($items);
+        $class = app(SiteDefaults::class);
+
+        return new $class($items);
     }
 
     /**


### PR DESCRIPTION
With this PR, you can now override where site defaults are stored by providing a custom `SiteDefaults` implementation:

```php
$this->app->bind(\Statamic\SeoPro\SiteDefaults::class, \App\MySiteDefaults::class);
```

This is for @ryanmitchell to store site defaults in a database by overloading the save and getDefaults methods ❤️

Closes #298 (This PR is just a slightly simpler alternative)