### PR TITLE
Add cascade hydration for custom route/controller/blade implementations

### DIFF
--- a/src/Directives/SeoProDirective.php
+++ b/src/Directives/SeoProDirective.php
@@ -26,7 +26,15 @@ class SeoProDirective extends SeoProTags
 
     protected function getContextFromCascade()
     {
-        return Cascade::instance()->toArray();
+        $cascade = Cascade::instance();
+
+        // If the cascade has not yet been hydrated, ensure it is hydrated.
+        // This is important for people using custom route/controller/view implementations.
+        if (empty($cascade->toArray())) {
+            $cascade->hydrate();
+        }
+
+        return $cascade->toArray();
     }
 
     protected function getContextFromCurrentRouteData()

--- a/tests/MetaTagTest.php
+++ b/tests/MetaTagTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests;
 
+use Facades\Statamic\View\Cascade as StatamicViewCacade;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Route;
 use Statamic\Extensions\Pagination\LengthAwarePaginator as StatamicLengthAwarePaginator;
 use Statamic\Facades\Blink;
-use Statamic\Facades\Cascade as StatamicViewCacade;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Config;
 use Statamic\Facades\Entry;

--- a/tests/MetaTagTest.php
+++ b/tests/MetaTagTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Route;
 use Statamic\Extensions\Pagination\LengthAwarePaginator as StatamicLengthAwarePaginator;
 use Statamic\Facades\Blink;
+use Statamic\Facades\Cascade as StatamicViewCacade;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Config;
 use Statamic\Facades\Entry;
@@ -27,6 +28,14 @@ class MetaTagTest extends TestCase
                 'title' => 'The View',
                 'description' => 'A wonderful view!',
             ]);
+
+            Route::get('custom-get-route', function () {
+                StatamicViewCacade::hydrated(function ($cascade) {
+                    $cascade->set('title', 'Custom Route Entry Title');
+                });
+
+                return view('page');
+            });
         });
     }
 
@@ -744,6 +753,24 @@ EOT;
 
         $this->assertStringContainsString("<h1>{$viewType}</h1>", $content);
         $this->assertStringContainsString($this->normalizeMultilineString($expected), $content);
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider viewScenarioProvider
+     */
+    public function it_hydrates_cascade_on_custom_routes_using_blade_directive($viewType)
+    {
+        if ($viewType === 'antlers') {
+            $this->markTestSkipped();
+        }
+
+        $this->prepareViews($viewType);
+
+        $content = $this->get('/custom-get-route')->content();
+
+        $this->assertStringContainsString('<title>Custom Route Entry Title | Site Name</title>', $content);
     }
 
     protected function setCustomGlidePresetDimensions($app)


### PR DESCRIPTION
Through a support request with a user, we found that they have a custom app logic in a custom route/controller/blade implementation to show an entry, which broke SEO Pro meta because it did not have the proper entry data hydrated through a more typical statamic view.

This PR allows them to manually add their entry content to the cascade like so...

```php
class StoriesController extends Controller
{
    public function show(Entry $story)
    {
        // Add entry content to Statamic's view cascade...
        \Statamic\Facades\Cascade::withContent($story);

        // Custom app logic
        // ...

        // Return blade view
        return view('stories/story', [...]);
    }
```

Of course this is custom laravel app territory, but that's okay. The user will just need to be mindful about adding their entry content to the cascade in these scenarios where they bypass Statamic's typical route/controller/view flow 👍