### PR TITLE
Report generation performance improvements

### DIFF
--- a/config/seo-pro.php
+++ b/config/seo-pro.php
@@ -43,4 +43,8 @@ return [
         'excluded_sites' => [],
     ],
 
+    'reports' => [
+        'queue_chunk_size' => 1000,
+    ],
+
 ];

--- a/resources/views/reports/index.blade.php
+++ b/resources/views/reports/index.blade.php
@@ -28,9 +28,9 @@
                         @can('delete seo reports')
                             <td class="float-right">
                                 <dropdown-list>
-                                    <dropdown-item :text="__('seo-pro::messages.delete_report')" class="warning" @click="$refs.deleter.confirm()">
+                                    <dropdown-item :text="__('seo-pro::messages.delete_report')" class="warning" @click="$refs.deleter_{{ $report->id() }}.confirm()">
                                         <resource-deleter
-                                            ref="deleter"
+                                            ref="deleter_{{ $report->id() }}"
                                             resource-title="Report"
                                             route="{{ cp_route('seo-pro.reports.destroy', $report->id()) }}"
                                             redirect="{{ cp_route('seo-pro.reports.index') }}"

--- a/src/Http/Controllers/ReportController.php
+++ b/src/Http/Controllers/ReportController.php
@@ -36,7 +36,7 @@ class ReportController extends CpController
         $report = Report::find($id);
 
         if ($request->ajax()) {
-            return $this->showOrGenerateReport($report);
+            return $report->data();
         }
 
         return view('seo-pro::reports.show', ['report' => $report]);
@@ -47,16 +47,5 @@ class ReportController extends CpController
         abort_unless(User::current()->can('delete seo reports'), 403);
 
         return Report::find($id)->delete();
-    }
-
-    private function showOrGenerateReport($report)
-    {
-        if ($report->status() === 'pending') {
-            $report = $report->queueGenerate();
-        } elseif ($report->isLegacyReport()) {
-            $report = $report->updateLegacyReport();
-        }
-
-        return $report->withPages();
     }
 }

--- a/src/Reporting/Chunk.php
+++ b/src/Reporting/Chunk.php
@@ -55,7 +55,7 @@ class Chunk
 
     protected function generate($ids)
     {
-        $content = Cache::get($this->report->contentCacheKey());
+        $content = Cache::get($this->report->cacheKey(Report::CONTENT_CACHE_KEY_SUFFIX));
 
         foreach ($ids as $id) {
             $this->createPage($content[$id] ?? Data::find($id))->save();

--- a/src/Reporting/Chunk.php
+++ b/src/Reporting/Chunk.php
@@ -55,7 +55,7 @@ class Chunk
     {
         collect($this->contentIds)
             ->map(fn ($id) => $this->createPage(Data::find($id)))
-            ->each(fn ($page) => $page->validate());
+            ->each(fn ($page) => $page->save());
 
         File::delete($this->folderPath());
     }

--- a/src/Reporting/Chunk.php
+++ b/src/Reporting/Chunk.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Statamic\SeoPro\Reporting;
+
+use Statamic\Facades\Data;
+use Statamic\Facades\File;
+use Statamic\Facades\YAML;
+use Statamic\SeoPro\Cascade;
+use Statamic\SeoPro\GetsSectionDefaults;
+use Statamic\SeoPro\SiteDefaults;
+
+class Chunk
+{
+    use GetsSectionDefaults;
+
+    public $id;
+    public $contentIds;
+    public $report;
+
+    public function __construct($id, $contentIds, Report $report)
+    {
+        $this->id = $id;
+        $this->contentIds = $contentIds;
+        $this->report = $report;
+    }
+
+    protected function folderPath()
+    {
+        return $this->report->chunksFolder()."/{$this->id}";
+    }
+
+    protected function yamlPath()
+    {
+        return $this->folderPath().'/chunk.yaml';
+    }
+
+    public function save()
+    {
+        File::put($this->yamlPath(), YAML::dump([
+            'ids' => $this->contentIds,
+        ]));
+
+        return $this;
+    }
+
+    public function queueGenerate()
+    {
+        // TODO: Create queueable `generate-chunk` command/job.
+        // Artisan::queue('statamic:seo-pro:generate-report', ['--report' => $this->id()]);
+
+        return $this;
+    }
+
+    public function generate()
+    {
+        collect($this->contentIds)
+            ->map(fn ($id) => $this->createPage(Data::find($id)))
+            ->each(fn ($page) => $page->validate());
+
+        File::delete($this->folderPath());
+    }
+
+    protected function createPage($content)
+    {
+        if ($content->value('seo') === false || is_null($content->uri())) {
+            return;
+        }
+
+        $data = (new Cascade)
+            ->with(SiteDefaults::load()->augmented())
+            ->with($this->getAugmentedSectionDefaults($content))
+            ->with($content->augmentedValue('seo')->value())
+            ->withCurrent($content)
+            ->get();
+
+        return new Page($content->id(), $data, $this->report);
+    }
+}

--- a/src/Reporting/Page.php
+++ b/src/Reporting/Page.php
@@ -5,13 +5,14 @@ namespace Statamic\SeoPro\Reporting;
 use Statamic\Facades\Data;
 use Statamic\Facades\File;
 use Statamic\Facades\YAML;
+use Statamic\Support\Arr;
 
 class Page
 {
-    protected $report;
-    protected $data;
-    protected $results;
     protected $id;
+    protected $data;
+    protected $report;
+    protected $results;
 
     protected $rules = [
         Rules\UniqueTitleTag::class,
@@ -20,23 +21,16 @@ class Page
         Rules\ThreeSegmentUrls::class,
     ];
 
-    public function setData($data)
+    public function __construct($id, $data, Report $report)
     {
-        $this->data = collect($data);
-
-        return $this;
+        $this->id = $id;
+        $this->data = $data;
+        $this->report = $report;
     }
 
     public function setResults($results)
     {
         $this->results = $results;
-
-        return $this;
-    }
-
-    public function setReport(Report $report)
-    {
-        $this->report = $report;
 
         return $this;
     }
@@ -75,7 +69,7 @@ class Page
 
     public function get($key)
     {
-        return $this->data->get($key);
+        return Arr::get($this->data, $key);
     }
 
     public function status()
@@ -129,18 +123,11 @@ class Page
         return $this->id;
     }
 
-    public function setId($id)
-    {
-        $this->id = $id;
-
-        return $this;
-    }
-
     public function save()
     {
         $data = [
             'id' => $this->id,
-            'data' => $this->data->all(),
+            'data' => $this->data,
             'results' => $this->results,
         ];
 

--- a/src/Reporting/Page.php
+++ b/src/Reporting/Page.php
@@ -14,13 +14,6 @@ class Page
     protected $report;
     protected $results;
 
-    protected $rules = [
-        Rules\UniqueTitleTag::class,
-        Rules\UniqueMetaDescription::class,
-        Rules\NoUnderscoresInUrl::class,
-        Rules\ThreeSegmentUrls::class,
-    ];
-
     public function __construct($id, $data, Report $report)
     {
         $this->id = $id;

--- a/src/Reporting/Page.php
+++ b/src/Reporting/Page.php
@@ -74,6 +74,10 @@ class Page
 
     public function status()
     {
+        if (! $this->results) {
+            return 'pending';
+        }
+
         $status = 'pass';
 
         foreach ($this->getRuleResults() as $result) {
@@ -92,6 +96,10 @@ class Page
     public function getRuleResults()
     {
         $results = collect();
+
+        if (! $this->results) {
+            return $results;
+        }
 
         foreach ($this->results as $class => $array) {
             $class = "Statamic\\SeoPro\\Reporting\\Rules\\$class";

--- a/src/Reporting/Report.php
+++ b/src/Reporting/Report.php
@@ -42,9 +42,9 @@ class Report implements Arrayable, Jsonable
     {
         $report = new static;
 
-        $report->setId($id ?: static::nextId());
-
-        return $report;
+        return $report
+            ->clearCaches()
+            ->setId($id ?: static::nextId());
     }
 
     public function setId($id)
@@ -78,6 +78,8 @@ class Report implements Arrayable, Jsonable
         if ($this->isGenerating()) {
             return $this;
         }
+
+        $this->clearCaches();
 
         Cache::put($this->cacheKey(static::GENERATING_CACHE_KEY_SUFFIX), true);
 
@@ -354,7 +356,7 @@ class Report implements Arrayable, Jsonable
     {
         File::delete($this->parentFolder());
 
-        return $this;
+        return $this->clearCaches();
     }
 
     public function parentFolder()
@@ -500,6 +502,16 @@ class Report implements Arrayable, Jsonable
     public function cacheKey($name)
     {
         return 'seo-pro-report-'.$this->id().'-'.$name;
+    }
+
+    public function clearCaches()
+    {
+        Cache::forget($this->cacheKey(static::GENERATING_CACHE_KEY_SUFFIX));
+        Cache::forget($this->cacheKey(static::CONTENT_CACHE_KEY_SUFFIX));
+        Cache::forget($this->cacheKey(static::PAGES_CACHE_KEY_SUFFIX));
+        Cache::forget($this->cacheKey(static::TO_ARRAY_CACHE_KEY_SUFFIX));
+
+        return $this;
     }
 
     public function isLegacyReport()

--- a/src/Reporting/Report.php
+++ b/src/Reporting/Report.php
@@ -247,6 +247,17 @@ class Report implements Arrayable, Jsonable
         return $this;
     }
 
+    public function data()
+    {
+        if ($this->status() === 'pending') {
+            return $this->queueGenerate()->withPages();
+        } elseif ($this->isLegacyReport()) {
+            return $this->updateLegacyReport()->withPages();
+        }
+
+        return $this->withPages();
+    }
+
     public static function all()
     {
         $folders = collect(Folder::getFolders(static::preparePath()));

--- a/src/Reporting/Report.php
+++ b/src/Reporting/Report.php
@@ -151,10 +151,7 @@ class Report implements Arrayable, Jsonable
                     ->withCurrent($content)
                     ->get();
 
-                return (new Page)
-                    ->setId($content->id())
-                    ->setData($data)
-                    ->setReport($this);
+                return new Page($content->id(), $data, $this);
             })
             ->filter();
     }
@@ -167,11 +164,7 @@ class Report implements Arrayable, Jsonable
         $this->pages = collect($files)->map(function ($file) {
             $yaml = YAML::parse(File::get($file));
 
-            return (new Page)
-                ->setId($yaml['id'])
-                ->setData($yaml['data'])
-                ->setResults($yaml['results'])
-                ->setReport($this);
+            return (new Page($yaml['id'], $yaml['data'], $this))->setResults($yaml['results']);
         });
 
         return $this;

--- a/src/Reporting/Report.php
+++ b/src/Reporting/Report.php
@@ -112,7 +112,13 @@ class Report implements Arrayable, Jsonable
             ->allContent()
             ->chunk(50)
             ->map(function ($chunk, $id) {
-                return (new Chunk($id + 1, $chunk->map->id()->values()->all(), $this))->save();
+                return app()
+                    ->makeWith(Chunk::class, [
+                        'id' => $id + 1,
+                        'contentIds' => $chunk->map->id()->values()->all(),
+                        'report' => $this,
+                    ])
+                    ->save();
             });
 
         $this->save(); // Save to update report status now that we have chunks in storage

--- a/src/Reporting/Report.php
+++ b/src/Reporting/Report.php
@@ -303,7 +303,7 @@ class Report implements Arrayable, Jsonable
     public function save()
     {
         File::put($this->path(), YAML::dump($this->raw = [
-            'date' => $this->date ?? time(),
+            'date' => $this->date ?? now()->timestamp,
             'status' => $this->status(),
             'score' => $this->score(),
             'pages_crawled' => $this->pagesCrawled(),

--- a/src/Reporting/Report.php
+++ b/src/Reporting/Report.php
@@ -127,8 +127,19 @@ class Report implements Arrayable, Jsonable
         }
 
         return $this
+            ->validatePages()
             ->validateSite()
             ->save();
+    }
+
+    protected function validatePages()
+    {
+        $this
+            ->withPages()
+            ->pages()
+            ->each(fn ($page) => $page->validate());
+
+        return $this;
     }
 
     protected function validateSite()

--- a/src/Reporting/Report.php
+++ b/src/Reporting/Report.php
@@ -219,9 +219,7 @@ class Report implements Arrayable, Jsonable
                     'results' => $page->getRuleResults(),
                 ];
             });
-        }
 
-        if ($this->isGenerated()) {
             Cache::put($this->cacheKey(static::TO_ARRAY_CACHE_KEY_SUFFIX), $array);
         }
 

--- a/src/Reporting/Report.php
+++ b/src/Reporting/Report.php
@@ -117,7 +117,7 @@ class Report implements Arrayable, Jsonable
     {
         $chunks = $this
             ->allContent()
-            ->chunk(1000)
+            ->chunk(config('statamic.seo-pro.reports.queue_chunk_size'))
             ->map(function ($chunk, $id) {
                 return app()
                     ->makeWith(Chunk::class, [

--- a/src/Reporting/Rules/UniqueMetaDescription.php
+++ b/src/Reporting/Rules/UniqueMetaDescription.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\SeoPro\Reporting\Rules;
 
+use Statamic\Facades\Blink;
 use Statamic\SeoPro\Reporting\Rule;
 
 class UniqueMetaDescription extends Rule
@@ -43,9 +44,19 @@ class UniqueMetaDescription extends Rule
 
     public function processPage()
     {
-        $this->count = $this->page->report()->pages()->filter(function ($page) {
-            return $page->get('description') === $this->metaDescription();
-        })->count();
+        $this->count = $this
+            ->groupAllPagesByDescription()
+            ->get($this->metaDescription())
+            ->count();
+    }
+
+    protected function groupAllPagesByDescription()
+    {
+        return Blink::once('seo-pro-report-'.$this->report->id().'-page-descriptions-grouped', function () {
+            return $this->page->report()->pages()->mapToGroups(function ($page) {
+                return [$page->get('description') => $page->id()];
+            });
+        });
     }
 
     public function savePage()

--- a/src/Reporting/Rules/UniqueTitleTag.php
+++ b/src/Reporting/Rules/UniqueTitleTag.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\SeoPro\Reporting\Rules;
 
+use Statamic\Facades\Blink;
 use Statamic\SeoPro\Reporting\Rule;
 
 class UniqueTitleTag extends Rule
@@ -43,9 +44,19 @@ class UniqueTitleTag extends Rule
 
     public function processPage()
     {
-        $this->count = $this->page->report()->pages()->filter(function ($page) {
-            return $page->get('title') === $this->title();
-        })->count();
+        $this->count = $this
+            ->groupAllPagesByTitle()
+            ->get($this->title())
+            ->count();
+    }
+
+    protected function groupAllPagesByTitle()
+    {
+        return Blink::once('seo-pro-report-'.$this->report->id().'-page-titles-grouped', function () {
+            return $this->page->report()->pages()->mapToGroups(function ($page) {
+                return [$page->get('title') => $page->id()];
+            });
+        });
     }
 
     public function savePage()

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -129,4 +129,16 @@ EXPECTED;
 
         return $this;
     }
+
+    /**
+     * Normalize line endings before performing assertion in windows.
+     */
+    public static function assertEquals($needle, $haystack, $message = ''): void
+    {
+        parent::assertEquals(
+            is_string($needle) ? static::normalizeMultilineString($needle) : $needle,
+            is_string($haystack) ? static::normalizeMultilineString($haystack) : $haystack,
+            $message
+        );
+    }
 }

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Support\Carbon;
+use Statamic\Facades\Entry;
+use Statamic\Facades\Term;
+use Statamic\SeoPro\Reporting\Report;
+use Statamic\Support\Str;
+
+class ReportTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Entry::all()->each->delete();
+        Term::all()->each->delete();
+
+        if ($this->files->exists($path = $this->reportsPath())) {
+            $this->files->deleteDirectory($path);
+        }
+    }
+
+    /** @test */
+    public function it_can_save_pending_report()
+    {
+        $this->assertFileNotExists($this->reportsPath());
+
+        Carbon::setTestNow($now = now());
+        Report::create()->save();
+
+        $this->assertCount(1, $this->files->directories($this->reportsPath()));
+        $this->assertFileExists($this->reportsPath('1'));
+
+        $expected = <<<"EXPECTED"
+date: $now->timestamp
+status: pending
+score: null
+pages_crawled: null
+results: null
+
+EXPECTED;
+
+        $this->assertCount(1, $this->files->allFiles($this->reportsPath('1')));
+        $this->assertEquals($expected, $this->files->get($this->reportsPath('1/report.yaml')));
+    }
+
+    /** @test */
+    public function it_increments_report_folder_numbers()
+    {
+        $this->assertFileNotExists($this->reportsPath());
+
+        Report::create()->save();
+        Report::create()->save();
+        Report::create()->save();
+
+        $this->assertCount(3, $this->files->directories($this->reportsPath()));
+        $this->assertFileExists($this->reportsPath('1'));
+        $this->assertFileExists($this->reportsPath('2'));
+        $this->assertFileExists($this->reportsPath('3'));
+    }
+
+    /** @test */
+    public function it_can_generate_a_report()
+    {
+        $this
+            ->generateEntries(5)
+            ->generateTerms(5);
+
+        $this->assertFileNotExists($this->reportsPath());
+
+        Carbon::setTestNow($now = now());
+        Report::create()->save()->generate();
+
+        $expected = <<<"EXPECTED"
+date: $now->timestamp
+status: fail
+score: 75.0
+pages_crawled: 10
+results:
+  SiteName: true
+  UniqueTitleTag: 0
+  UniqueMetaDescription: 10
+  NoUnderscoresInUrl: 0
+  ThreeSegmentUrls: 0
+
+EXPECTED;
+
+        $this->assertCount(1, $this->files->files($this->reportsPath('1')));
+        $this->assertEquals($expected, $this->files->get($this->reportsPath('1/report.yaml')));
+
+        $this->assertFileExists($this->reportsPath('1/pages'));
+        $this->assertCount(10, $this->files->directories($this->reportsPath('1/pages')));
+    }
+
+    public function reportsPath($path = null)
+    {
+        if ($path) {
+            $path = Str::ensureLeft($path, '/');
+        }
+
+        return storage_path('statamic/seopro/reports').$path;
+    }
+
+    protected function generateEntries($count)
+    {
+        collect(range(1, $count))->each(function ($i) {
+            Entry::make()
+                ->collection('articles')
+                ->blueprint('article')
+                ->slug('test-entry-'.$i)
+                ->set('title', 'Test Entry '.$i)
+                ->save();
+        });
+
+        return $this;
+    }
+
+    protected function generateTerms($count)
+    {
+        collect(range(1, $count))->each(function ($i) {
+            Term::make()
+                ->slug($slug = 'test-term-'.$i)
+                ->taxonomy('topics')
+                ->set('title', 'Test Term '.$i)
+                ->save();
+        });
+
+        return $this;
+    }
+}

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -91,7 +91,7 @@ EXPECTED;
         $this->assertEquals($expected, $this->files->get($this->reportsPath('1/report.yaml')));
 
         $this->assertFileExists($this->reportsPath('1/pages'));
-        $this->assertCount(10, $this->files->directories($this->reportsPath('1/pages')));
+        $this->assertCount(10, $this->files->allFiles($this->reportsPath('1/pages')));
     }
 
     public function reportsPath($path = null)

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use Illuminate\Support\Carbon;
 use Statamic\Facades\Blink;
+use Statamic\Facades\Config;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Term;
 use Statamic\SeoPro\Reporting\Chunk;
@@ -99,12 +100,11 @@ EXPECTED;
     /** @test */
     public function it_can_generate_a_large_report_with_multiple_chunked_jobs()
     {
-        // We chunk content into chunks of 50.
-        // 60 entries and 60 terms totals 120 pages.
-        // This should mean 3 chunks, which we'll assert below.
+        Config::set('statamic.seo-pro.reports.queue_chunk_size', 3);
+
         $this
-            ->generateEntries(60)
-            ->generateTerms(60);
+            ->generateEntries(5)
+            ->generateTerms(5);
 
         $this->assertFileNotExists($this->reportsPath());
 
@@ -114,18 +114,18 @@ EXPECTED;
         Carbon::setTestNow($now = now());
         Report::create()->save()->generate();
 
-        // Assert we saved exactly three chunks.
-        $this->assertEquals(3, Blink::get('saving-chunk'));
+        // Assert we saved exactly four chunks, based on our above config, and the number of pages being generated.
+        $this->assertEquals(4, Blink::get('saving-chunk'));
 
         $expected = <<<"EXPECTED"
 date: $now->timestamp
 status: fail
-score: 68.0
-pages_crawled: 120
+score: 75.0
+pages_crawled: 10
 results:
   SiteName: true
   UniqueTitleTag: 0
-  UniqueMetaDescription: 120
+  UniqueMetaDescription: 10
   NoUnderscoresInUrl: 0
   ThreeSegmentUrls: 0
 
@@ -137,7 +137,7 @@ EXPECTED;
         $this->assertEquals($expected, $this->files->get($this->reportsPath('1/report.yaml')));
 
         $this->assertFileExists($this->reportsPath('1/pages'));
-        $this->assertCount(120, $this->files->allFiles($this->reportsPath('1/pages')));
+        $this->assertCount(10, $this->files->allFiles($this->reportsPath('1/pages')));
     }
 
     public function reportsPath($path = null)


### PR DESCRIPTION
This PR massively improves report generation performance overall (up to 10x faster compared to current version 5.3.0, and up to 4x faster compared to master branch right now). It also adds the ability to chunk generation into smaller jobs for super large sites with thousands of entries.

For example, report generation on 5.3.0 (current version) for even 1000 pages is 60+ seconds with a request timeout...

![CleanShot 2023-12-23 at 02 03 25](https://github.com/statamic/seo-pro/assets/5187394/5dcfe573-f161-4543-8742-af3041124e63)

But with this PR, 1000 pages takes me ~7 seconds, which is about 10x faster 🏎️...

![CleanShot 2023-12-23 at 02 06 10](https://github.com/statamic/seo-pro/assets/5187394/83bb4b28-177c-43ba-aef0-0a7af89af7b8)

But where this PR really shines is when generating reports for massive sites with thousands of entries, which you can't even do on 5.3.0 (as shown above in our 1000 page example).

On master (untagged), we can at least generate a report for 5000 pages, but it takes me about ~52 seconds...

![CleanShot 2023-12-23 at 00 53 27 2](https://github.com/statamic/seo-pro/assets/5187394/953a70e8-6b16-467c-845a-355aca30b629)

With this PR though, the same 5000 pages takes about ~29 seconds, which is nearly 2x faster 🏎️

![CleanShot 2023-12-23 at 01 12 38](https://github.com/statamic/seo-pro/assets/5187394/5c8e50f0-b96b-4244-bd6a-31937826407d)

And if I enable async queue driver w/ 5 workers (chunked in jobs of 1000 pages each), the report generation endpoint takes about ~13 seconds, which is about 4x faster compared to master, and not even possible on 5.3.0 🏎️

## Configuration

I have made the chunk size configurable in `config/statamic/seo-pro.php` under `reports.queue_chunk_size`, so that users can balance chunk size vs. worker count how they like.

## Note on CPU

Of course your mileage will vary. It's pretty CPU intensive when generating a report for this many entries. The above numbers are just locally on my M1 Macbook.