### PR TITLE
Fix save on null error

### DIFF
--- a/src/Reporting/Chunk.php
+++ b/src/Reporting/Chunk.php
@@ -58,7 +58,7 @@ class Chunk
         $content = Cache::get($this->report->cacheKey(Report::CONTENT_CACHE_KEY_SUFFIX));
 
         foreach ($ids as $id) {
-            $this->createPage($content[$id] ?? Data::find($id))->save();
+            $this->createPage($content[$id] ?? Data::find($id))?->save();
         }
 
         File::delete($this->folderPath());


### PR DESCRIPTION
Fixes https://github.com/statamic/seo-pro/issues/312

Happens when SEO is disabled on a page...

![CleanShot 2024-01-08 at 12 58 02](https://github.com/statamic/seo-pro/assets/5187394/6b725afd-ed2c-41df-acef-2015ba9091a7)
