### PR TITLE
Always show `Custom` image option

### DIFF
--- a/src/HasAssetField.php
+++ b/src/HasAssetField.php
@@ -12,13 +12,33 @@ trait HasAssetField
     protected static function getAssetFieldConfig()
     {
         if (! $container = config('statamic.seo-pro.assets.container')) {
-            return false;
+            return static::getAssetFieldContainerError();
         }
 
         return [
             'type' => 'assets',
             'container' => $container,
             'max_files' => 1,
+        ];
+    }
+
+    /**
+     * Show helpful asset field config error.
+     *
+     * @return array
+     */
+    protected static function getAssetFieldContainerError()
+    {
+        return [
+            'type' => 'html',
+            'html' => <<<'HTML'
+<div class="mt-2 text-sm text-red-500">
+    Asset container not configured.
+    <a class="text-red-500 underline" href="https://statamic.com/addons/statamic/seo-pro/docs#advanced-configuration" target="_blank">
+        Learn more
+    </a>
+</div>
+HTML,
         ];
     }
 }


### PR DESCRIPTION
People always ask about this one, so let's always show `Custom` image option, with more helpful error when not properly configured...

![CleanShot 2024-05-10 at 13 26 24](https://github.com/statamic/seo-pro/assets/5187394/48255c10-f344-42bb-859f-b0f24d5135b3)

References https://github.com/statamic/seo-pro/issues/327