### PR TITLE
Replace `starts_with()` with `Str::startsWith()`

### DIFF
--- a/src/Reporting/Page.php
+++ b/src/Reporting/Page.php
@@ -6,6 +6,7 @@ use Statamic\Facades\Data;
 use Statamic\Facades\File;
 use Statamic\Facades\YAML;
 use Statamic\Support\Arr;
+use Statamic\Support\Str;
 
 class Page
 {
@@ -152,7 +153,7 @@ class Page
 
     public function editUrl()
     {
-        if (starts_with($this->id, 'route:')) {
+        if (Str::startsWith($this->id, 'route:')) {
             return route('settings.edit', ['settings' => 'routes']);
         }
 


### PR DESCRIPTION
In Statamic 5, [we dropped our dependency](https://github.com/statamic/cms/pull/9811) on the `laravel/helpers` package which provided a variety of array & string helper methods that ultimately pointed towards Laravel's `Arr` and `Str` classes.

One of the methods it provides was `starts_with`, which since it doesn't exist, was causing errors when attempting to view reports in SEO Pro.

Fixes #329.