### PR TITLE
Support paginated sitemaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ composer.lock
 /vendor
 .phpunit.result.cache
 .phpunit.cache
+.idea/

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     },
     "require-dev": {
         "orchestra/testbench": "^8.0 || ^9.0",
-        "phpunit/phpunit": "^10.0"
+        "phpunit/phpunit": "^10.0",
+        "laravel/pint": "^1.17"
     },
     "config": {
         "allow-plugins": {

--- a/config/seo-pro.php
+++ b/config/seo-pro.php
@@ -22,7 +22,7 @@ return [
         'enabled' => true,
         'url' => 'sitemap.xml',
         'expire' => 60,
-        'paginated' => true,
+        'paginated' => false,
         'paginated_limit' => 25,
         'paginated_url' => 'sitemap_{id}.xml',
     ],

--- a/config/seo-pro.php
+++ b/config/seo-pro.php
@@ -24,8 +24,8 @@ return [
         'expire' => 60,
         'pagination' => [
             'enabled' => false,
-            'limit' => 100,
             'url' => 'sitemap_{page}.xml',
+            'limit' => 100,
         ],
     ],
 

--- a/config/seo-pro.php
+++ b/config/seo-pro.php
@@ -22,9 +22,11 @@ return [
         'enabled' => true,
         'url' => 'sitemap.xml',
         'expire' => 60,
-        'paginated' => false,
-        'paginated_limit' => 100,
-        'paginated_url' => 'sitemap_{id}.xml',
+        'pagination' => [
+            'enabled' => false,
+            'limit' => 100,
+            'url' => 'sitemap_{id}.xml',
+        ],
     ],
 
     'humans' => [

--- a/config/seo-pro.php
+++ b/config/seo-pro.php
@@ -22,6 +22,9 @@ return [
         'enabled' => true,
         'url' => 'sitemap.xml',
         'expire' => 60,
+        'paginated' => true,
+        'paginated_limit' => 25,
+        'paginated_url' => 'sitemap_{id}.xml',
     ],
 
     'humans' => [

--- a/config/seo-pro.php
+++ b/config/seo-pro.php
@@ -23,7 +23,7 @@ return [
         'url' => 'sitemap.xml',
         'expire' => 60,
         'paginated' => false,
-        'paginated_limit' => 25,
+        'paginated_limit' => 100,
         'paginated_url' => 'sitemap_{id}.xml',
     ],
 

--- a/config/seo-pro.php
+++ b/config/seo-pro.php
@@ -25,7 +25,7 @@ return [
         'pagination' => [
             'enabled' => false,
             'limit' => 100,
-            'url' => 'sitemap_{id}.xml',
+            'url' => 'sitemap_{page}.xml',
         ],
     ],
 

--- a/resources/views/generated/sitemap_index.antlers.html
+++ b/resources/views/generated/sitemap_index.antlers.html
@@ -1,8 +1,8 @@
 {{ xml_header }}
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-    {{ sitemaps }}
+{{ sitemaps }}
     <sitemap>
-        <loc>{{  url  }}</loc>
+        <loc>{{ url }}</loc>
     </sitemap>
-    {{ /sitemaps }}
+{{ /sitemaps }}
 </sitemapindex>

--- a/resources/views/generated/sitemap_index.antlers.html
+++ b/resources/views/generated/sitemap_index.antlers.html
@@ -1,0 +1,8 @@
+{{ xml_header }}
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    {{ sitemaps }}
+    <sitemap>
+        <loc>{{  url  }}</loc>
+    </sitemap>
+    {{ /sitemaps }}
+</sitemapindex>

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,4 +3,5 @@
 use Statamic\SeoPro\Http\Controllers;
 
 Route::get(config('statamic.seo-pro.sitemap.url'), [Controllers\SitemapController::class, 'show']);
+Route::get(config('statamic.seo-pro.sitemap.paginated_url'), [Controllers\SitemapController::class, 'show'])->name('statamic.seo-pro.sitemap.paginated');
 Route::get(config('statamic.seo-pro.humans.url'), [Controllers\HumansController::class, 'show']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,6 @@
 
 use Statamic\SeoPro\Http\Controllers;
 
-Route::get(config('statamic.seo-pro.sitemap.url'), [Controllers\SitemapController::class, 'show']);
-Route::get(config('statamic.seo-pro.sitemap.pagination.url'), [Controllers\SitemapController::class, 'show'])->name('statamic.seo-pro.sitemap.paginated');
+Route::get(config('statamic.seo-pro.sitemap.url'), [Controllers\SitemapController::class, 'index']);
+Route::get(config('statamic.seo-pro.sitemap.pagination.url'), [Controllers\SitemapController::class, 'show'])->name('statamic.seo-pro.sitemap.page.show');
 Route::get(config('statamic.seo-pro.humans.url'), [Controllers\HumansController::class, 'show']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,5 +3,5 @@
 use Statamic\SeoPro\Http\Controllers;
 
 Route::get(config('statamic.seo-pro.sitemap.url'), [Controllers\SitemapController::class, 'show']);
-Route::get(config('statamic.seo-pro.sitemap.paginated_url'), [Controllers\SitemapController::class, 'show'])->name('statamic.seo-pro.sitemap.paginated');
+Route::get(config('statamic.seo-pro.sitemap.pagination.url'), [Controllers\SitemapController::class, 'show'])->name('statamic.seo-pro.sitemap.paginated');
 Route::get(config('statamic.seo-pro.humans.url'), [Controllers\HumansController::class, 'show']);

--- a/src/Http/Controllers/SitemapController.php
+++ b/src/Http/Controllers/SitemapController.php
@@ -16,7 +16,7 @@ class SitemapController extends Controller
         $cacheUntil = Carbon::now()->addMinutes(config('statamic.seo-pro.sitemap.expire'));
         $cacheKey = Sitemap::CACHE_KEY;
 
-        if (config('statamic.seo-pro.sitemap.paginated', false)) {
+        if (config('statamic.seo-pro.sitemap.pagination.enabled', false)) {
             if ($page !== null) {
                 if (! filter_var($page, FILTER_VALIDATE_INT)) {
                     abort(404);
@@ -33,11 +33,11 @@ class SitemapController extends Controller
 
             $view = 'seo-pro::sitemap';
 
-            if (! config('statamic.seo-pro.sitemap.paginated', false)) {
+            if (! config('statamic.seo-pro.sitemap.pagination.enabled', false)) {
                 $data['pages'] = Sitemap::pages();
             }
 
-            if (config('statamic.seo-pro.sitemap.paginated', false)) {
+            if (config('statamic.seo-pro.sitemap.pagination.enabled', false)) {
                 if ($page === null) {
                     $data['sitemaps'] = Sitemap::paginatedSitemaps();
                     $view = 'seo-pro::sitemap_index';

--- a/src/Http/Controllers/SitemapController.php
+++ b/src/Http/Controllers/SitemapController.php
@@ -43,6 +43,10 @@ class SitemapController extends Controller
                     $view = 'seo-pro::sitemap_index';
                 } else {
                     $data['pages'] = Sitemap::paginatedPages($page);
+
+                    if (empty($data['pages'])) {
+                        abort(404);
+                    }
                 }
             }
 

--- a/src/Sitemap/Sitemap.php
+++ b/src/Sitemap/Sitemap.php
@@ -36,7 +36,7 @@ class Sitemap
     {
         $sitemap = new static;
 
-        $perPage = config('statamic.seo-pro.sitemap.paginated_limit', 100);
+        $perPage = config('statamic.seo-pro.sitemap.pagination.limit', 100);
         $offset = ($page - 1) * $perPage;
         $remaining = $perPage;
 
@@ -82,7 +82,7 @@ class Sitemap
         // would be nice to make terms a count query rather than getting the count from the terms collection
         $count = $sitemap->publishedEntriesCount() + $sitemap->publishedTerms()->count() + $sitemap->publishedCollectionTerms()->count();
 
-        $sitemapCount = ceil($count / config('statamic.seo-pro.sitemap.paginated_limit', 100));
+        $sitemapCount = ceil($count / config('statamic.seo-pro.sitemap.pagination.limit', 100));
 
         $sitemaps = [];
         for ($i = 1; $i <= $sitemapCount; $i++) {

--- a/src/Sitemap/Sitemap.php
+++ b/src/Sitemap/Sitemap.php
@@ -75,7 +75,7 @@ class Sitemap
     {
         $sitemap = new static;
 
-        // at the moment we have to get all entries to get this count, not ideal
+        // would be nice to make terms a count query rather than getting the count from the terms collection
         $count = $sitemap->publishedEntriesCount() + $sitemap->publishedTerms()->count() + $sitemap->publishedCollectionTerms()->count();
 
         $sitemapCount = ceil($count / config('statamic.seo-pro.sitemap.paginated_limit', 100));

--- a/src/Sitemap/Sitemap.php
+++ b/src/Sitemap/Sitemap.php
@@ -65,6 +65,10 @@ class Sitemap
             );
         }
 
+        if ($pages->isEmpty()) {
+            return [];
+        }
+
         return $sitemap->getPages($pages)
             ->values()
             ->map
@@ -81,7 +85,7 @@ class Sitemap
         $sitemapCount = ceil($count / config('statamic.seo-pro.sitemap.paginated_limit', 100));
 
         $sitemaps = [];
-        for ($i=1; $i <= $sitemapCount; $i++) {
+        for ($i = 1; $i <= $sitemapCount; $i++) {
             $sitemaps[] = ['url' => route('statamic.seo-pro.sitemap.paginated', ['id' => $i])];
         }
 
@@ -126,7 +130,8 @@ class Sitemap
         return Entry::query()
             ->whereIn('collection', $collections)
             ->whereNotNull('uri')
-            ->whereStatus('published');
+            ->whereStatus('published')
+            ->orderBy('uri');
     }
 
     protected function publishedEntries()

--- a/src/Sitemap/Sitemap.php
+++ b/src/Sitemap/Sitemap.php
@@ -84,12 +84,9 @@ class Sitemap
 
         $sitemapCount = ceil($count / config('statamic.seo-pro.sitemap.pagination.limit', 100));
 
-        $sitemaps = [];
-        for ($i = 1; $i <= $sitemapCount; $i++) {
-            $sitemaps[] = ['url' => route('statamic.seo-pro.sitemap.paginated', ['id' => $i])];
-        }
-
-        return $sitemaps;
+        return collect(range(1, $sitemapCount))
+            ->map(fn ($page) => ['url' => route('statamic.seo-pro.sitemap.page.show', ['page' => $page])])
+            ->all();
     }
 
     protected function getPages($items)

--- a/tests/SitemapTest.php
+++ b/tests/SitemapTest.php
@@ -235,16 +235,17 @@ EOT;
         $expected = <<<'EOT'
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-    
+
     <sitemap>
         <loc>http://cool-runnings.com/sitemap_1.xml</loc>
     </sitemap>
-    
+
     <sitemap>
         <loc>http://cool-runnings.com/sitemap_2.xml</loc>
     </sitemap>
-    
+
 </sitemapindex>
+
 EOT;
 
         $this->assertEquals($expected, $content);

--- a/tests/SitemapTest.php
+++ b/tests/SitemapTest.php
@@ -223,8 +223,8 @@ EOT;
     /** @test */
     public function it_outputs_paginated_sitemap_index_xml()
     {
-        config()->set('statamic.seo-pro.sitemap.paginated', true);
-        config()->set('statamic.seo-pro.sitemap.paginated_limit', 5);
+        config()->set('statamic.seo-pro.sitemap.pagination.enabled', true);
+        config()->set('statamic.seo-pro.sitemap.pagination.limit', 5);
 
         $content = $this
             ->get('/sitemap.xml')
@@ -254,8 +254,8 @@ EOT;
     /** @test */
     public function it_outputs_paginated_sitemap_page_xml()
     {
-        config()->set('statamic.seo-pro.sitemap.paginated', true);
-        config()->set('statamic.seo-pro.sitemap.paginated_limit', 5);
+        config()->set('statamic.seo-pro.sitemap.pagination.enabled', true);
+        config()->set('statamic.seo-pro.sitemap.pagination.limit', 5);
 
         $content = $this
             ->get('/sitemap_1.xml')
@@ -350,8 +350,8 @@ EOT;
     /** @test */
     public function it_404s_on_invalid_pagination_urls()
     {
-        config()->set('statamic.seo-pro.sitemap.paginated', true);
-        config()->set('statamic.seo-pro.sitemap.paginated_limit', 5);
+        config()->set('statamic.seo-pro.sitemap.pagination.enabled', true);
+        config()->set('statamic.seo-pro.sitemap.pagination.limit', 5);
 
         $this
             ->get('/sitemap_3.xml')


### PR DESCRIPTION
This PR enables the generation of paginated sitemaps through a sitemap index file that references sitemaps containing the links to entries and terms. See: https://developers.google.com/search/docs/crawling-indexing/sitemaps/large-sitemaps

When enabled through the new config this ensures that sitemaps generated in a more performant, as by default we only place 100 items in the sitemap, though you can change this value in the config file.

Along the way I've also refactored the publishedEntries querying to be more performant by deferring to the query builder for filtering and using a whereIn for the collection handles. This change also allows us to do a count() on the query site, rather than getting all items and then count()-ing.