### PR TITLE
Add fallback URL for sitemap route

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -3,5 +3,5 @@
 use Statamic\SeoPro\Http\Controllers;
 
 Route::get(config('statamic.seo-pro.sitemap.url'), [Controllers\SitemapController::class, 'index']);
-Route::get(config('statamic.seo-pro.sitemap.pagination.url'), [Controllers\SitemapController::class, 'show'])->name('statamic.seo-pro.sitemap.page.show');
+Route::get(config('statamic.seo-pro.sitemap.pagination.url', 'sitemap_{page}.xml'), [Controllers\SitemapController::class, 'show'])->name('statamic.seo-pro.sitemap.page.show');
 Route::get(config('statamic.seo-pro.humans.url'), [Controllers\HumansController::class, 'show']);


### PR DESCRIPTION
This pull request fixes an issue where the frontend of sites would error out after upgrading to 6.1.0, which introduced support for paginated sitemaps: #344.

The error was happening due to the `statamic.seo-pro.sitemap.pagination.url` not being set on existing site's `seo-pro.php` config files. 

Fixes #345.