### PR TITLE
Site defaults supporting multisite

### DIFF
--- a/config/seo-pro.php
+++ b/config/seo-pro.php
@@ -3,7 +3,7 @@
 return [
 
     'site_defaults' => [
-        'path' => base_path('content/seo.yaml'),
+        'path' => base_path('content/seo'),
     ],
 
     'assets' => [

--- a/src/SiteDefaults.php
+++ b/src/SiteDefaults.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Collection;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\File;
+use Statamic\Facades\Site;
 use Statamic\Facades\YAML;
 use Statamic\SeoPro\Events\SeoProSiteDefaultsSaved;
 
@@ -99,7 +100,13 @@ class SiteDefaults extends Collection
      */
     protected function path()
     {
-        return config('statamic.seo-pro.site_defaults.path');
+        $path = str_replace('.yaml', '', config()->string('statamic.seo-pro.site_defaults.path'));
+
+        if (! config()->boolean('statamic.system.multisite')) {
+            return $path.'.yaml';
+        }
+
+        return $path.'/'.Site::selected()->handle.'/seo.yaml';
     }
 
     /**

--- a/src/SiteDefaults.php
+++ b/src/SiteDefaults.php
@@ -3,6 +3,7 @@
 namespace Statamic\SeoPro;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\File;
@@ -100,13 +101,15 @@ class SiteDefaults extends Collection
      */
     protected function path()
     {
-        $path = str_replace('.yaml', '', config()->string('statamic.seo-pro.site_defaults.path'));
-
-        if (! config()->boolean('statamic.system.multisite')) {
-            return $path.'.yaml';
-        }
-
-        return $path.'/'.Site::selected()->handle.'/seo.yaml';
+        return Str::of(config()->string("statamic.seo-pro.site_defaults.path"))
+            ->chopEnd(".yaml")
+            ->when(
+                config()->boolean("statamic.system.multisite"),
+                fn($path) => $path->append(
+                    vsprintf("%s/%s", [Site::selected()->handle, "defaults"])
+                )
+            )
+            ->append(".yaml");
     }
 
     /**

--- a/src/SiteDefaults.php
+++ b/src/SiteDefaults.php
@@ -3,14 +3,12 @@
 namespace Statamic\SeoPro;
 
 use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\File;
 use Statamic\Facades\Site;
 use Statamic\Facades\YAML;
 use Statamic\SeoPro\Events\SeoProSiteDefaultsSaved;
-use Illuminate\Support\Stringable;
 
 class SiteDefaults extends Collection
 {
@@ -102,16 +100,21 @@ class SiteDefaults extends Collection
      */
     protected function path()
     {
-        return Str::of((string) config("statamic.seo-pro.site_defaults.path"))
-            ->chopEnd([".yaml", "/"])
-            ->when(
-                (bool) config("statamic.system.multisite"),
-                fn(Stringable $path) => $path->append(
-                    vsprintf("/%s/%s", [Site::selected()->handle, "defaults"])
-                )
-            )
-            ->append(".yaml")
-            ->__toString();
+        $path = config('statamic.seo-pro.site_defaults.path');
+
+        if (str_ends_with($path, '.yaml')) {
+            $path = str_replace('.yaml', '', $path);
+        }
+
+        if (str_ends_with($path, '/')) {
+            $path = rtrim($path, '/');
+        }
+
+        if (config('statamic.system.multisite')) {
+            return vsprintf('%s/%s/%s.yaml', [$path, Site::selected()->handle, 'defaults']);
+        }
+
+        return $path.'.yaml';
     }
 
     /**

--- a/src/SiteDefaults.php
+++ b/src/SiteDefaults.php
@@ -10,6 +10,7 @@ use Statamic\Facades\File;
 use Statamic\Facades\Site;
 use Statamic\Facades\YAML;
 use Statamic\SeoPro\Events\SeoProSiteDefaultsSaved;
+use Illuminate\Support\Stringable;
 
 class SiteDefaults extends Collection
 {
@@ -105,7 +106,7 @@ class SiteDefaults extends Collection
             ->chopEnd([".yaml", "/"])
             ->when(
                 config()->boolean("statamic.system.multisite"),
-                fn($path) => $path->append(
+                fn(Stringable $path) => $path->append(
                     vsprintf("/%s/%s", [Site::selected()->handle, "defaults"])
                 )
             )

--- a/src/SiteDefaults.php
+++ b/src/SiteDefaults.php
@@ -102,10 +102,10 @@ class SiteDefaults extends Collection
      */
     protected function path()
     {
-        return Str::of(config()->string("statamic.seo-pro.site_defaults.path"))
+        return Str::of((string) config("statamic.seo-pro.site_defaults.path"))
             ->chopEnd([".yaml", "/"])
             ->when(
-                config()->boolean("statamic.system.multisite"),
+                (bool) config("statamic.system.multisite"),
                 fn(Stringable $path) => $path->append(
                     vsprintf("/%s/%s", [Site::selected()->handle, "defaults"])
                 )

--- a/src/SiteDefaults.php
+++ b/src/SiteDefaults.php
@@ -102,11 +102,11 @@ class SiteDefaults extends Collection
     protected function path()
     {
         return Str::of(config()->string("statamic.seo-pro.site_defaults.path"))
-            ->chopEnd(".yaml")
+            ->chopEnd([".yaml", "/"])
             ->when(
                 config()->boolean("statamic.system.multisite"),
                 fn($path) => $path->append(
-                    vsprintf("%s/%s", [Site::selected()->handle, "defaults"])
+                    vsprintf("/%s/%s", [Site::selected()->handle, "defaults"])
                 )
             )
             ->append(".yaml");

--- a/src/SiteDefaults.php
+++ b/src/SiteDefaults.php
@@ -109,7 +109,8 @@ class SiteDefaults extends Collection
                     vsprintf("/%s/%s", [Site::selected()->handle, "defaults"])
                 )
             )
-            ->append(".yaml");
+            ->append(".yaml")
+            ->__toString();
     }
 
     /**


### PR DESCRIPTION
With this PR support is being added for multisite.
Fallback is added when using a config file with path to the yaml file.

output paths will be ./content/seo/sitehandle/defaults.yaml

Closes #289.