### PR TITLE
Allow customization of sitemap queries

### DIFF
--- a/src/Http/Controllers/SitemapController.php
+++ b/src/Http/Controllers/SitemapController.php
@@ -19,14 +19,14 @@ class SitemapController extends Controller
             $content = Cache::remember(Sitemap::CACHE_KEY.'_index', $cacheUntil, function () {
                 return view('seo-pro::sitemap_index', [
                     'xml_header' => '<?xml version="1.0" encoding="UTF-8"?>',
-                    'sitemaps' => Sitemap::paginatedSitemaps(),
+                    'sitemaps' => app(Sitemap::class)->paginatedSitemaps(),
                 ])->render();
             });
         } else {
             $content = Cache::remember(Sitemap::CACHE_KEY, $cacheUntil, function () {
                 return view('seo-pro::sitemap', [
                     'xml_header' => '<?xml version="1.0" encoding="UTF-8"?>',
-                    'pages' => Sitemap::pages(),
+                    'pages' => app(Sitemap::class)->pages(),
                 ])->render();
             });
         }
@@ -45,7 +45,7 @@ class SitemapController extends Controller
         $cacheKey = Sitemap::CACHE_KEY.'_'.$page;
 
         $content = Cache::remember($cacheKey, $cacheUntil, function () use ($page) {
-            abort_if(empty($pages = Sitemap::paginatedPages($page)), 404);
+            abort_if(empty($pages = app(Sitemap::class)->paginatedPages($page)), 404);
 
             return view('seo-pro::sitemap', [
                 'xml_header' => '<?xml version="1.0" encoding="UTF-8"?>',

--- a/src/Sitemap/Sitemap.php
+++ b/src/Sitemap/Sitemap.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\SeoPro\Sitemap;
 
+use Illuminate\Support\LazyCollection;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
@@ -128,12 +129,12 @@ class Sitemap
             ->orderBy('uri');
     }
 
-    protected function publishedEntries()
+    protected function publishedEntries(): LazyCollection
     {
         return $this->publishedEntriesQuery()->lazy();
     }
 
-    protected function publishedEntriesCount()
+    protected function publishedEntriesCount(): int
     {
         return $this->publishedEntriesQuery()->count();
     }

--- a/src/Sitemap/Sitemap.php
+++ b/src/Sitemap/Sitemap.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\SeoPro\Sitemap;
 
+use Illuminate\Support\Collection as IlluminateCollection;
 use Illuminate\Support\LazyCollection;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Collection;
@@ -42,7 +43,7 @@ class Sitemap
         $entryCount = $this->publishedEntriesCount() - 1;
 
         if ($offset < $entryCount) {
-            $entries = $this->publishedEntriesQuery()->offset($offset)->limit($perPage)->get();
+            $entries = $this->publishedEntriesForPage($page, $perPage);
 
             if ($entries->count() < $remaining) {
                 $remaining -= $entries->count();
@@ -132,6 +133,17 @@ class Sitemap
     protected function publishedEntries(): LazyCollection
     {
         return $this->publishedEntriesQuery()->lazy();
+    }
+
+    protected function publishedEntriesForPage(int $page, int $perPage): IlluminateCollection
+    {
+        $offset = ($page - 1) * $perPage;
+
+        return $this
+            ->publishedEntriesQuery()
+            ->offset($offset)
+            ->limit($perPage)
+            ->get();
     }
 
     protected function publishedEntriesCount(): int

--- a/tests/SitemapTest.php
+++ b/tests/SitemapTest.php
@@ -3,11 +3,13 @@
 namespace Tests;
 
 use Illuminate\Support\Collection as IlluminateCollection;
+use Statamic\Console\Composer\Lock;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Config;
 use Statamic\Facades\Entry;
 use Statamic\SeoPro\Sitemap\Sitemap;
+use Statamic\Statamic;
 
 class SitemapTest extends TestCase
 {
@@ -372,6 +374,13 @@ EOT;
     /** @test */
     public function it_can_use_custom_sitemap_queries()
     {
+        // Hacky/temporary version compare, because `reorder()` method we're using
+        // in CustomSitemap class below requires 5.29.0+, and we don't want to
+        // increase minimum required Statamic version just for test setup
+        if (version_compare(ltrim(Lock::file(__DIR__.'/../composer.lock')->getInstalledVersion('statamic/cms'), 'v'), '5.29.0', '<')) {
+            $this->markTestSkipped();
+        }
+
         app()->bind(Sitemap::class, CustomSitemap::class);
 
         config()->set('statamic.seo-pro.sitemap.pagination.enabled', true);

--- a/tests/SitemapTest.php
+++ b/tests/SitemapTest.php
@@ -2,13 +2,16 @@
 
 namespace Tests;
 
+use Illuminate\Support\Collection as IlluminateCollection;
+use Statamic\Facades\Blink;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Config;
 use Statamic\Facades\Entry;
+use Statamic\SeoPro\Sitemap\Sitemap;
 
 class SitemapTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -364,5 +367,131 @@ EOT;
         $this
             ->get('/sitemap_a.xml')
             ->assertNotFound();
+    }
+
+    /** @test */
+    public function it_can_use_custom_sitemap_queries()
+    {
+        app()->bind(Sitemap::class, CustomSitemap::class);
+
+        config()->set('statamic.seo-pro.sitemap.pagination.enabled', true);
+        config()->set('statamic.seo-pro.sitemap.pagination.limit', 5);
+
+        $this->assertNull(Blink::get('ran-custom-entries-query'));
+        $this->assertNull(Blink::get('ran-custom-entries-for-page-query'));
+
+        $content = $this
+            ->get('/sitemap_1.xml')
+            ->assertOk()
+            ->assertHeader('Content-Type', 'text/xml; charset=UTF-8')
+            ->getContent();
+
+        $this->assertEquals(2, Blink::get('ran-custom-entries-query'));
+        $this->assertEquals(1, Blink::get('ran-custom-entries-for-page-query'));
+        $this->assertCount(5, $this->getPagesFromSitemapXml($content));
+
+        $today = now()->format('Y-m-d');
+
+        $expected = <<<"EOT"
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+
+    <url>
+        <loc>http://cool-runnings.com/articles</loc>
+        <lastmod>2020-01-17</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.5</priority>
+    </url>
+
+    <url>
+        <loc>http://cool-runnings.com/dance</loc>
+        <lastmod>$today</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.5</priority>
+    </url>
+
+    <url>
+        <loc>http://cool-runnings.com/magic</loc>
+        <lastmod>$today</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.5</priority>
+    </url>
+
+    <url>
+        <loc>http://cool-runnings.com/nectar</loc>
+        <lastmod>$today</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.5</priority>
+    </url>
+
+    <url>
+        <loc>http://cool-runnings.com/topics</loc>
+        <lastmod>2020-01-20</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.5</priority>
+    </url>
+
+</urlset>
+
+EOT;
+
+        $this->assertEquals($expected, $content);
+
+        $content = $this
+            ->get('/sitemap_2.xml')
+            ->assertOk()
+            ->assertHeader('Content-Type', 'text/xml; charset=UTF-8')
+            ->getContent();
+
+        $this->assertEquals(4, Blink::get('ran-custom-entries-query'));
+        $this->assertEquals(2, Blink::get('ran-custom-entries-for-page-query'));
+        $this->assertCount(2, $this->getPagesFromSitemapXml($content));
+
+        $today = now()->format('Y-m-d');
+
+        $expected = <<<'EOT'
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+
+    <url>
+        <loc>http://cool-runnings.com</loc>
+        <lastmod>2020-11-24</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.5</priority>
+    </url>
+
+    <url>
+        <loc>http://cool-runnings.com/about</loc>
+        <lastmod>2020-01-17</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.5</priority>
+    </url>
+
+</urlset>
+
+EOT;
+
+        $this->assertEquals($expected, $content);
+    }
+}
+
+class CustomSitemap extends Sitemap
+{
+    protected function publishedEntriesQuery()
+    {
+        // count how many times this is called
+        Blink::increment('ran-custom-entries-query');
+
+        // reversing from default order, just so we can assert query has effect on output
+        return parent::publishedEntriesQuery()->reorder('uri', 'desc');
+    }
+
+    protected function publishedEntriesForPage(int $page, int $perPage): IlluminateCollection
+    {
+        // count how many times this is called
+        Blink::increment('ran-custom-entries-for-page-query');
+
+        // also reverse items on individual pages, again so we can assert query has effect on output
+        return parent::publishedEntriesForPage($page, $perPage)->reverse();
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -12,6 +12,7 @@ use Statamic\SeoPro\SiteDefaults;
 abstract class TestCase extends \Orchestra\Testbench\TestCase
 {
     protected $siteFixturePath = __DIR__.'/Fixtures/site';
+    protected $files;
 
     protected function getPackageProviders($app)
     {


### PR DESCRIPTION
As a result support issue for TV2, we're realizing that paginated sitemaps break down with extremely large data sets, due to needing more control over the queries, index optimization, etc.

The problem with index optimization is that how indexes are chosen is finicky, and each database engine will have it's differences/opinions around this.

To help with scalability, this PR does two things:

1) It allows the user to extend and bind their own implementation of our `Sitemap` class.

2) It extracts the paginated sitemap query to a dedicated method that [is more easily overridable](https://github.com/statamic/seo-pro/commit/7799b3b4ac89a83815385476dd8fde3fa90ebbe9).