### PR TITLE
Allow aliasing on `{{ seo_pro:meta_data }}` tag

### DIFF
--- a/src/Directives/SeoProDirective.php
+++ b/src/Directives/SeoProDirective.php
@@ -16,7 +16,10 @@ class SeoProDirective extends SeoProTags
             );
         }
 
-        return $this->setContext($context)->$tag();
+        return $this
+            ->setContext($context)
+            ->setParameters([])
+            ->$tag();
     }
 
     protected function isMissingContext($context)

--- a/src/Tags/SeoProTags.php
+++ b/src/Tags/SeoProTags.php
@@ -49,7 +49,7 @@ class SeoProTags extends Tags
         $metaData['is_twitter_glide_enabled'] = $this->isGlidePresetEnabled('seo_pro_twitter');
         $metaData['is_og_glide_enabled'] = $this->isGlidePresetEnabled('seo_pro_og');
 
-        return $metaData;
+        return $this->aliasedResult($metaData);
     }
 
     /**

--- a/tests/Fixtures/site/content/collections/pages/about.md
+++ b/tests/Fixtures/site/content/collections/pages/about.md
@@ -1,5 +1,6 @@
 ---
 title: About
+subtitle: The Best About Page
 updated_by: 96300192-873c-4615-b992-157508a8d7c5
 updated_at: 1579284102
 template: page


### PR DESCRIPTION
Currently, the only way (I know of) to access "Section Defaults" or values "from field" is to do something like this:
```
{{ seo_pro:meta_data }}
    {{ title }}
{{ /seo_pro:meta_data }}
```

The above overrides the context values, which is not something you always want.

With this small change, you'll be able to do something like:
```
{{ seo_pro:meta_data as="seo_meta" }}
    {{ seo_meta:title }}
{{ /seo_pro:meta_data }}
```
which leaves the context alone.

I'm referring to these settings:
![image](https://github.com/user-attachments/assets/ff6a917f-dd96-4b58-b35d-8b4b7fbf3b9a)

