### PR TITLE
Update addon name in `composer.json` should be "SEO Pro"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     },
     "extra": {
         "statamic": {
-            "name": "Seo Pro",
+            "name": "SEO Pro",
             "description": "An all-in-one site reporting, metadata mastering, OG managing, Twitter card making, sitemap generating addon."
         },
         "laravel": {


### PR DESCRIPTION
Currently, when this addon is displayed in the addons list on the "Updater" page, it shows as `Seo Pro`, instead of `SEO Pro`:

![CleanShot 2025-01-06 at 10 25 36](https://github.com/user-attachments/assets/8b4de114-74c3-444f-a21c-16bbeaefea3e)
