### PR TITLE
Fix null error when using with SSG

### DIFF
--- a/src/Cascade.php
+++ b/src/Cascade.php
@@ -383,7 +383,7 @@ class Cascade
     {
         $viewCascade = app(ViewCascade::class)->toArray();
 
-        return (string) Parse::template($item, array_merge($viewCascade, $this->current));
+        return (string) Parse::template($item, array_merge($viewCascade, $this->current ?? []));
     }
 
     protected function humans()


### PR DESCRIPTION
When using SEO Pro with Statamic SSG, and you have a custom route:

```antlers
Route::statamic('/custom', 'pages.custom', [
    'seo' => [
        'title' => 'Custom Title',
        'description' => 'Custom Description',
    ]
]);
```

For some reason `$this->current` on the `parseAntlers` function returns `null` which throws an error during builds. 
