### PR TITLE
Fix PHP in antlers

### DIFF
--- a/src/Cascade.php
+++ b/src/Cascade.php
@@ -381,6 +381,10 @@ class Cascade
 
     protected function parseAntlers($item)
     {
+        if (Str::contains($item, ['{{?', '{{$'])) {
+            return $item;
+        }
+
         $viewCascade = app(ViewCascade::class)->toArray();
 
         return (string) Parse::template($item, array_merge($viewCascade, $this->current));


### PR DESCRIPTION
When using antlers syntax (as documented)...

![image](https://github.com/user-attachments/assets/f07285ac-d308-42ba-9e7b-c6b1e533fc76)

The antlers parser automatically disallows `<?php`, but `{{?` and `{{$` should be disallowed too.