### PR TITLE
Tighten up sanitization of seo meta

### DIFF
--- a/resources/views/meta.antlers.html
+++ b/resources/views/meta.antlers.html
@@ -7,7 +7,7 @@
 {{ /if }}
 
 {{ if robots }}
-    <meta name="robots" content="{{ robots | raw | list }}" />
+    <meta name="robots" content="{{ robots | raw | list | striptags | entities }}" />
 {{ /if }}
 
 <meta property="og:type" content="website" />
@@ -37,7 +37,7 @@
 <meta name="twitter:card" content="{{ twitter_card }}" />
 
 {{ if twitter_handle }}
-    <meta name="twitter:site" content="{{ twitter_handle | trim | ensure_left:@ }}" />
+    <meta name="twitter:site" content="{{ twitter_handle | striptags | entities | trim | ensure_left:@ }}" />
 {{ /if }}
 
 {{ if title }}
@@ -62,7 +62,7 @@
             <meta property="og:image:width" content="{{ width }}" />
             <meta property="og:image:height" content="{{ height }}" />
         {{ /if }}
-        <meta property="og:image:alt" content="{{ alt }}" />
+        <meta property="og:image:alt" content="{{ alt | striptags | entities }}" />
 
         {{ if is_twitter_glide_enabled }}
             {{ glide:generate :src="image" preset="seo_pro_twitter" absolute="true" }}
@@ -71,7 +71,7 @@
         {{ else }}
             <meta name="twitter:image" content="{{ permalink }}" />
         {{ /if }}
-        <meta name="twitter:image:alt" content="{{ alt }}" />
+        <meta name="twitter:image:alt" content="{{ alt | striptags | entities }}" />
 
     {{ /image }}
 {{ /if }}
@@ -99,9 +99,9 @@
 {{ /if }}
 
 {{ if google_verification }}
-    <meta name="google-site-verification" content="{{ google_verification }}" />
+    <meta name="google-site-verification" content="{{ google_verification | striptags | entities }}" />
 {{ /if }}
 
 {{ if bing_verification }}
-    <meta name="msvalidate.01" content="{{ bing_verification }}" />
+    <meta name="msvalidate.01" content="{{ bing_verification | striptags | entities }}" />
 {{ /if }}


### PR DESCRIPTION
We already `striptags | entities` on much of our output meta data. This PR tightens this up across all output meta.