### PR TITLE
Fix localized seo fields for Eloquent driver users

### DIFF
--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -61,7 +61,12 @@ class Blueprint
 
         static::$addingField = true;
 
-        $this->blueprint->ensureFieldInTab('seo', ['type' => 'seo_pro', 'listable' => false, 'display' => 'SEO'], 'SEO');
+        $this->blueprint->ensureFieldInTab('seo', [
+            'type' => 'seo_pro',
+            'listable' => false,
+            'display' => 'SEO',
+            'localizable' => true,
+        ], 'SEO');
 
         static::$addingField = false;
     }


### PR DESCRIPTION
Statamic's [Eloquent driver](https://github.com/statamic/eloquent-driver) tracks `__localized_fields` on entry save to determine which fields should be included in localized data.

Even though `seo` field data was being saved, it was not properly showing in the control panel or in front end SEO meta for Eloquent users because the parent `seo` field was not being tracked by `__localized_fields`...

![CleanShot 2025-05-07 at 11 30 46](https://github.com/user-attachments/assets/244c082d-0ee4-45f5-8c7b-ca292b786a8e)

This PR makes the parent `seo` field localizable, so that it can be tracked by `__localized_fields` in Eloquent...

![CleanShot 2025-05-07 at 11 33 55](https://github.com/user-attachments/assets/990b59c2-c9ff-4d4b-8d48-656214cdf528)

_Note: Child fields [within the seo array](https://github.com/statamic/seo-pro/blob/4ebb6b84e361824f8b0d567f653f9c7284114d4f/src/Fields.php#L63) were already marked localizable, but this was more for the purpose of making child fields editable, since non-localizable fieldtypes are rendered as read-only inputs in the CP UI. This never affected Stache usage, but the parent `seo` field also needs to be localizable for `__localized_fields` as stated above._

Fixes #339