### PR TITLE
Fix failing PHP code tests

### DIFF
--- a/tests/CascadeTest.php
+++ b/tests/CascadeTest.php
@@ -143,7 +143,7 @@ class CascadeTest extends TestCase
             ],
             [
                 "{{ _php_used = (['' => ''] | json); _open = (_php_used | at(0)); _close = (_php_used | at(6)); _antlers_modified = _open + _open + '? echo \"php used\" ?' + _close + _close; _antlers_modified | antlers /}}",
-                '{{? echo "php used" ?}}',
+                "{{ _php_used = (['' => ''] | json); _open = (_php_used | at(0)); _close = (_php_used | at(6)); _antlers_modified = _open + _open + '? echo \"php used\" ?' + _close + _close; _antlers_modified | antlers /}}",
             ],
         ];
     }

--- a/tests/CascadeTest.php
+++ b/tests/CascadeTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests;
 
-use Illuminate\Support\Facades\Log;
 use Statamic\Facades\Config;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Site;
@@ -142,31 +141,11 @@ class CascadeTest extends TestCase
                 "{{ _php_used = '@{@{' + '? echo \"php used\" ?' + '@}}'; _php_used | antlers /}}",
                 "{{ _php_used = '@{@{' + '? echo \"php used\" ?' + '@}}'; _php_used | antlers /}}",
             ],
-        ];
-    }
-
-    public static function obfuscatedPhpInAntlersProvider()
-    {
-        return [
             [
                 "{{ _php_used = (['' => ''] | json); _open = (_php_used | at(0)); _close = (_php_used | at(6)); _antlers_modified = _open + _open + '? echo \"php used\" ?' + _close + _close; _antlers_modified | antlers /}}",
-                'PHP Node evaluated in user content: {{? echo "php used" ?}}',
-                ' echo "php used" ',
+                '{{? echo "php used" ?}}',
             ],
         ];
-    }
-
-    private function getAntlersPhpData($antlers)
-    {
-        $entry = Entry::findByUri('/about')->entry();
-
-        return (new Cascade)
-            ->with(SiteDefaults::load()->all())
-            ->with([
-                'description' => $antlers,
-            ])
-            ->withCurrent($entry)
-            ->get();
     }
 
     /**
@@ -176,28 +155,18 @@ class CascadeTest extends TestCase
      */
     public function it_doesnt_parse_php_in_antlers($antlers, $output)
     {
-        $data = $this->getAntlersPhpData($antlers);
+        $entry = Entry::findByUri('/about')->entry();
+
+        $data = (new Cascade)
+            ->with(SiteDefaults::load()->all())
+            ->with([
+                'description' => $antlers,
+            ])
+            ->withCurrent($entry)
+            ->get();
 
         $this->assertNotEquals('php used', $data['description']);
         $this->assertEquals($output, $data['description']);
-    }
-
-    /**
-     * @test
-     *
-     * @dataProvider obfuscatedPhpInAntlersProvider
-     */
-    public function it_doesnt_parse_obfuscated_php_in_antlers($antlers, $logMessage, $phpContent)
-    {
-        Log::shouldReceive('warning')->once()->with($logMessage, [
-            'file' => null,
-            'trace' => [],
-            'content' => $phpContent,
-        ]);
-
-        $data = $this->getAntlersPhpData($antlers);
-
-        $this->assertSame('', $data['description']);
     }
 
     /** @test */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -73,6 +73,9 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
             $app['config']->set("statamic.$config", require (__DIR__."/../vendor/statamic/cms/config/{$config}.php"));
         }
 
+        $app['config']->set('app.debug', true);
+        $app['config']->set('statamic.antlers.errorOnAccessViolation', true);
+
         $files = new Filesystem;
 
         $files->copyDirectory(__DIR__.'/../vendor/statamic/cms/config', config_path('statamic'));


### PR DESCRIPTION
This PR corrects some failing tests by forcing the runtime to throw exceptions when PHP nodes are encountered within user-supplied content.

The fix in https://github.com/statamic/cms/pull/11800 corrected an undefined property error. When an exception was thrown previously, it was being swallowed by this catch block: https://github.com/statamic/cms/blob/5.x/src/View/Antlers/Language/Runtime/ModifierManager.php#L132, allowing the original text to the modifier to be returned when the application was not in debug mode. For the currently failing test, it would have been [the dynamically constructed PHP block](https://github.com/statamic/seo-pro/blob/master/tests/CascadeTest.php#L146).

The ideal way to test this would be to assert a log being created, but that would cause failing tests when using `--prefer-lowest`. This refactored test is relying [on the fact SEO Pro returns the original text if an exception is thrown](https://github.com/statamic/seo-pro/blob/master/src/Cascade.php#L408), which will be consistent across all Statamic versions when `app.debug` is `true`, and throwing exceptions when PHP nodes are encountered is enabled. Note: these settings are not important to actually prevent execution of PHP code (that is handled by the runtime), but just a way to observe it from SEO Pro across multiple Statamic versions 🙂


