### PR TITLE
Allow enforcement of trailing slashes on urls and links

### DIFF
--- a/config/seo-pro.php
+++ b/config/seo-pro.php
@@ -22,6 +22,7 @@ return [
         'enabled' => true,
         'url' => 'sitemap.xml',
         'expire' => 60,
+        'enforce_trailing_slashes' => false,
         'pagination' => [
             'enabled' => false,
             'url' => 'sitemap_{page}.xml',

--- a/src/Cascade.php
+++ b/src/Cascade.php
@@ -91,7 +91,7 @@ class Cascade
             'canonical_url' => $this->canonicalUrl(),
             'prev_url' => $this->prevUrl(),
             'next_url' => $this->nextUrl(),
-            'home_url' => Str::removeRight(URL::makeAbsolute('/'), '/'),
+            'home_url' => URL::makeAbsolute('/'),
             'humans_txt' => $this->humans(),
             'site' => $this->site(),
             'alternate_locales' => $alternateLocales = $this->alternateLocales(),

--- a/src/Http/Controllers/SitemapController.php
+++ b/src/Http/Controllers/SitemapController.php
@@ -5,6 +5,7 @@ namespace Statamic\SeoPro\Http\Controllers;
 use Carbon\Carbon;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Cache;
+use Statamic\Facades\URL;
 use Statamic\SeoPro\Sitemap\Sitemap;
 
 class SitemapController extends Controller
@@ -12,6 +13,10 @@ class SitemapController extends Controller
     public function index()
     {
         abort_unless(config('statamic.seo-pro.sitemap.enabled'), 404);
+
+        if (config('statamic.seo-pro.sitemap.enforce_trailing_slashes')) {
+            URL::enforceTrailingSlashes();
+        }
 
         $cacheUntil = Carbon::now()->addMinutes(config('statamic.seo-pro.sitemap.expire'));
 
@@ -39,6 +44,10 @@ class SitemapController extends Controller
         abort_unless(config('statamic.seo-pro.sitemap.enabled'), 404);
         abort_unless(config('statamic.seo-pro.sitemap.pagination.enabled'), 404);
         abort_unless(filter_var($page, FILTER_VALIDATE_INT), 404);
+
+        if (config('statamic.seo-pro.sitemap.enforce_trailing_slashes')) {
+            URL::enforceTrailingSlashes();
+        }
 
         $cacheUntil = Carbon::now()->addMinutes(config('statamic.seo-pro.sitemap.expire'));
 


### PR DESCRIPTION
Still experimental, but this PR adds config to enforce trailing slashes on urls and links in generated SEO meta and in the sitemap. This is useful on server hosts that bias towards trailing slashes (ie. Netlify [expects trailing slashes for SEO](https://github.com/statamic/seo-pro/issues/387#issuecomment-2917533542)).

## Todo

- [x] Add opt-in config
  - [ ] Config for enforcing in generated meta
    - Need to think through config for this more
    - Should reset `URL::enforceTrailingSlashes()` back to previous value immediately after generating meta
  - [x] Config for enforcing on sitemap
- [x] Wire up config to enforce trailing slashes in relevant classes only
  - We don't want this always running in the service provider, because it will affect the rest of the site
  - If a user wants trailing slashes on whole site, they can `URL::enforceTrailingSlashes()` in their provider
  - If a user wants trailing slashes on SSG generated sites, [we've added a proper SSG config for that here](https://github.com/statamic/ssg/pull/203)
- [ ] Flesh out test coverage
	- Everything seems to be working when testing manually though! 💅
- [ ] Decide on minimum Statamic version
    - Do we require Statamic 6+, or can we just note in the config file that this feature requires 6+?

References https://github.com/statamic/seo-pro/issues/387