### PR TITLE
Require Statamic v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     },
     "require": {
-        "statamic/cms": "dev-url-trailing-slashes as 6.0"
+        "statamic/cms": "^6.0"
     },
     "require-dev": {
         "orchestra/testbench": "^9.6.1 || ^10.0",


### PR DESCRIPTION
Reference v6 directly now that trailing slashes is in the `master` branch