### PR TITLE
Update NPM dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
             "dependencies": {
                 "cross-env": "^7.0.2",
                 "underscore": "~1.12.1",
-                "vue": "^2.6.11"
+                "vue": "^2.7.16"
             },
             "devDependencies": {
                 "@vitejs/plugin-vue2": "^2.3.3",
@@ -15,15 +15,50 @@
                 "vite": "^6.0.0"
             }
         },
+        "node_modules/@babel/helper-string-parser": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-identifier": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+            "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@babel/parser": {
-            "version": "7.21.8",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.8.tgz",
-            "integrity": "sha512-6zavDGdzG3gUqAdWvlLFfk+36RilI+Pwyuuh7HItyeScCWP3k6i8vKclAQ0bM/0y/Kz/xiwvxhMv9MgTJP5gmA==",
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+            "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.28.4"
+            },
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/types": {
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+            "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
@@ -798,13 +833,16 @@
             }
         },
         "node_modules/@vue/compiler-sfc": {
-            "version": "2.7.14",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.14.tgz",
-            "integrity": "sha512-aNmNHyLPsw+sVvlQFQ2/8sjNuLtK54TC6cuKnVzAY93ks4ZBrvwQSnkkIh7bsbNhum5hJBS00wSDipQ937f5DA==",
+            "version": "2.7.16",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.16.tgz",
+            "integrity": "sha512-KWhJ9k5nXuNtygPU7+t1rX6baZeqOYLEforUPjgNDBnLicfHCoi48H87Q8XyLZOrNNsmhuwKqtpDQWjEFe6Ekg==",
             "dependencies": {
-                "@babel/parser": "^7.18.4",
+                "@babel/parser": "^7.23.5",
                 "postcss": "^8.4.14",
                 "source-map": "^0.6.1"
+            },
+            "optionalDependencies": {
+                "prettier": "^1.18.2 || ^2.0.0"
             }
         },
         "node_modules/cross-env": {
@@ -1015,6 +1053,22 @@
                 "node": "^10 || ^12 || >=14"
             }
         },
+        "node_modules/prettier": {
+            "version": "2.8.8",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+            "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+            "license": "MIT",
+            "optional": true,
+            "bin": {
+                "prettier": "bin-prettier.js"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
         "node_modules/rollup": {
             "version": "4.52.2",
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.2.tgz",
@@ -1080,6 +1134,7 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -1215,11 +1270,13 @@
             }
         },
         "node_modules/vue": {
-            "version": "2.7.14",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.14.tgz",
-            "integrity": "sha512-b2qkFyOM0kwqWFuQmgd4o+uHGU7T+2z3T+WQp8UBjADfEv2n4FEMffzBmCKNP0IGzOEEfYjvtcC62xaSKeQDrQ==",
+            "version": "2.7.16",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.16.tgz",
+            "integrity": "sha512-4gCtFXaAA3zYZdTp5s4Hl2sozuySsgz4jy1EnpBHNfpMa9dK1ZCG7viqBPCwXtmgc8nHqUsAu3G4gtmXkkY3Sw==",
+            "deprecated": "Vue 2 has reached EOL and is no longer actively maintained. See https://v2.vuejs.org/eol/ for more details.",
+            "license": "MIT",
             "dependencies": {
-                "@vue/compiler-sfc": "2.7.14",
+                "@vue/compiler-sfc": "2.7.16",
                 "csstype": "^3.1.0"
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
             },
             "devDependencies": {
                 "@vitejs/plugin-vue2": "^2.3.3",
-                "laravel-vite-plugin": "^2.0.1",
-                "vite": "^7.1.7"
+                "laravel-vite-plugin": "^1.3.0",
+                "vite": "^6.0.0"
             }
         },
         "node_modules/@babel/parser": {
@@ -923,9 +923,9 @@
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
         },
         "node_modules/laravel-vite-plugin": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-2.0.1.tgz",
-            "integrity": "sha512-zQuvzWfUKQu9oNVi1o0RZAJCwhGsdhx4NEOyrVQwJHaWDseGP9tl7XUPLY2T8Cj6+IrZ6lmyxlR1KC8unf3RLA==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-1.3.0.tgz",
+            "integrity": "sha512-P5qyG56YbYxM8OuYmK2OkhcKe0AksNVJUjq9LUZ5tOekU9fBn9LujYyctI4t9XoLjuMvHJXXpCoPntY1oKltuA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -936,10 +936,10 @@
                 "clean-orphaned-assets": "bin/clean.js"
             },
             "engines": {
-                "node": "^20.19.0 || >=22.12.0"
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
             },
             "peerDependencies": {
-                "vite": "^7.0.0"
+                "vite": "^5.0.0 || ^6.0.0"
             }
         },
         "node_modules/nanoid": {
@@ -1116,24 +1116,24 @@
             "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
         },
         "node_modules/vite": {
-            "version": "7.1.7",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.7.tgz",
-            "integrity": "sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA==",
+            "version": "6.3.6",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.6.tgz",
+            "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.25.0",
-                "fdir": "^6.5.0",
-                "picomatch": "^4.0.3",
-                "postcss": "^8.5.6",
-                "rollup": "^4.43.0",
-                "tinyglobby": "^0.2.15"
+                "fdir": "^6.4.4",
+                "picomatch": "^4.0.2",
+                "postcss": "^8.5.3",
+                "rollup": "^4.34.9",
+                "tinyglobby": "^0.2.13"
             },
             "bin": {
                 "vite": "bin/vite.js"
             },
             "engines": {
-                "node": "^20.19.0 || >=22.12.0"
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
             },
             "funding": {
                 "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -1142,14 +1142,14 @@
                 "fsevents": "~2.3.3"
             },
             "peerDependencies": {
-                "@types/node": "^20.19.0 || >=22.12.0",
+                "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
                 "jiti": ">=1.21.0",
-                "less": "^4.0.0",
+                "less": "*",
                 "lightningcss": "^1.21.0",
-                "sass": "^1.70.0",
-                "sass-embedded": "^1.70.0",
-                "stylus": ">=0.54.8",
-                "sugarss": "^5.0.0",
+                "sass": "*",
+                "sass-embedded": "*",
+                "stylus": "*",
+                "sugarss": "*",
                 "terser": "^5.16.0",
                 "tsx": "^4.8.1",
                 "yaml": "^2.4.2"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     },
     "devDependencies": {
         "@vitejs/plugin-vue2": "^2.3.3",
-        "laravel-vite-plugin": "^2.0.1",
-        "vite": "^7.1.7"
+        "laravel-vite-plugin": "^1.3.0",
+        "vite": "^6.0.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dependencies": {
         "cross-env": "^7.0.2",
         "underscore": "~1.12.1",
-        "vue": "^2.6.11"
+        "vue": "^2.7.16"
     },
     "devDependencies": {
         "@vitejs/plugin-vue2": "^2.3.3",


### PR DESCRIPTION
This pull request fixes a dependency conflict caused by #408. The Vue 2 plugin isn't compatible with Vite 7, so I've downgraded to Vite 6.

I've also updated to the latest version of Vue 2. 