### PR TITLE
Add `folder` option to assets config

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -40,7 +40,7 @@ It's better to configure your collections and taxonomies to dynamically pull fro
 
 ### Assets
 
-If you wish to use assets in your meta, you can [publish the SEO Pro config](#advanced-configuration) and specify an asset container, as well as the glide preset to be used.
+If you wish to use assets in your meta, you can [publish the SEO Pro config](#advanced-configuration) and specify an asset container, as well as a folder and glide preset to be used.
 
 > You may disable the glide preset altogether by setting `'open_graph_preset' => false,` in your config.
 

--- a/config/seo-pro.php
+++ b/config/seo-pro.php
@@ -8,6 +8,7 @@ return [
 
     'assets' => [
         'container' => null,
+        'folder' => null,
         'twitter_preset' => [
             'w' => 1200,
             'h' => 600,

--- a/src/HasAssetField.php
+++ b/src/HasAssetField.php
@@ -18,6 +18,7 @@ trait HasAssetField
         return [
             'type' => 'assets',
             'container' => $container,
+            'folder' => config('statamic.seo-pro.assets.folder'),
             'max_files' => 1,
         ];
     }


### PR DESCRIPTION
This pull request adds a `folder` option to the assets config, allowing you to restrict which folder SEO images are stored in.

```php
// config/statamic/seo-pro.php

'assets' => [
    'container' => 'assets',
    'folder' => 'seo',
     // ...
],
```

Closes #77