### PR TITLE
Add check for builder to ensure we only get 1 image

### DIFF
--- a/src/Cascade.php
+++ b/src/Cascade.php
@@ -4,6 +4,7 @@ namespace Statamic\SeoPro;
 
 use Exception;
 use Illuminate\Support\Collection;
+use Statamic\Contracts\Query\Builder;
 use Statamic\Facades\Antlers;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Config;
@@ -377,7 +378,7 @@ class Cascade
 
     protected function parseImageField($value)
     {
-        return $value instanceof Collection
+        return $value instanceof Collection || $value instanceof Builder
             ? $value->first()
             : $value;
     }


### PR DESCRIPTION
parseImageCheck needed updated to check for a query builder or a collection, as both are now possible.

Closes https://github.com/statamic/seo-pro/issues/299