### PR TITLE
Exclude external entries from reports

### DIFF
--- a/src/Reporting/Report.php
+++ b/src/Reporting/Report.php
@@ -518,7 +518,7 @@ class Report implements Arrayable, Jsonable
     protected function allContent()
     {
         $content = collect()
-            ->merge(Entry::all())
+            ->merge(Entry::all()->whereNull('redirect'))
             ->merge(Term::all())
             ->keyBy
             ->id();


### PR DESCRIPTION
This pull request fixes an issue where linked/external entries were included in SEO Pro's reports, where they probably shouldn't be.

Fixes #388