### PR TITLE
Fix error when resolving social image via GraphQL

### DIFF
--- a/src/GraphQL/SeoProType.php
+++ b/src/GraphQL/SeoProType.php
@@ -87,7 +87,7 @@ class SeoProType extends Type
                 'resolve' => function ($meta) {
                     $image = $meta['image'] ?? null;
 
-                    if ($meta['image'] instanceof Value) {
+                    if ($image instanceof Value) {
                         $image = $meta['image']->value();
                     }
 


### PR DESCRIPTION
This pull request fixes an error which would occur when attempting to resolve a social image via GraphQL, if the image was set to come from another field.

Fixes #342