### PR TITLE
Pass config options & globals when parsing Antlers in `Cascade`

### DIFF
--- a/src/Cascade.php
+++ b/src/Cascade.php
@@ -8,6 +8,7 @@ use Statamic\Facades\Antlers;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Config;
 use Statamic\Facades\Entry;
+use Statamic\Facades\GlobalSet;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
 use Statamic\Fields\Field;
@@ -400,13 +401,33 @@ class Cascade
             $viewCascade = array_merge(
                 app(ViewCascade::class)->toArray(),
                 $this->current ?? [],
-                ['___tmpValue' => $value],
+                ['___tmpValue' => $value, 'config' => config()->all()],
+                $this->hydrateGlobals()
             );
 
             return (string) Antlers::parse('{{ ___tmpValue }}', $viewCascade);
         } catch (Exception $exception) {
             return $item;
         }
+    }
+
+    private function hydrateGlobals()
+    {
+        $data = [];
+
+        foreach ($globals = GlobalSet::all() as $global) {
+            if ($global = $global->in($this->site()->handle())) {
+                $data[$global->handle()] = $global;
+            }
+        }
+
+        if ($mainGlobal = $globals->get('global')) {
+            foreach ($mainGlobal->toDeferredAugmentedArray() as $key => $value) {
+                $data[$key] = $value;
+            }
+        }
+
+        return $data;
     }
 
     protected function humans()


### PR DESCRIPTION
This pull request fixes an issue when using Antlers in the "site name" option, where reports would complain about no site name being defined:

<img width="370" height="61" alt="CleanShot 2025-09-25 at 16 21 08" src="https://github.com/user-attachments/assets/4100a79a-17bc-4317-b605-51bf2c59506e" />

Normally, when the `Cascade` parses Antlers strings, it'll pass in data from Statamic's `Cascade` which will have been hydrated during Statamic's view lifecycle.

However, the `Cascade` isn't hydrated in the case of a report, so the site name was ending up empty.

This PR fixes it by always passing config options & global variables when parsing Antlers, ensuring they still work when the Cascade is empty.

Fixes #325