### PR TITLE
Widget should pull the latest generated report

### DIFF
--- a/src/Reporting/Report.php
+++ b/src/Reporting/Report.php
@@ -349,6 +349,11 @@ class Report implements Arrayable, Jsonable
         return static::all()->first();
     }
 
+    public static function latestGenerated()
+    {
+        return static::all()->filter(fn ($report) => $report->isGenerated())->first();
+    }
+
     public static function find($id)
     {
         $instance = static::create($id);

--- a/src/Widgets/SeoProWidget.php
+++ b/src/Widgets/SeoProWidget.php
@@ -10,7 +10,7 @@ class SeoProWidget extends Widget
     public function html()
     {
         return view('seo-pro::widget', [
-            'report' => Report::latest(),
+            'report' => Report::latestGenerated(),
         ]);
     }
 }


### PR DESCRIPTION
This pull request fixes an issue where the widget would show a 0% score because a report is in-progress. 

This PR fixes it by instead pulling the score of the latest **generated** report.

Fixes #263.