### PR TITLE
Improve SEO fields in Live Preview

### DIFF
--- a/resources/js/components/fieldtypes/SourceFieldtype.vue
+++ b/resources/js/components/fieldtypes/SourceFieldtype.vue
@@ -1,8 +1,6 @@
 <template>
-
-    <div class="flex">
-
-        <div class="source-type-select pr-4">
+    <div class="source-container flex gap-y-2 gap-x-4">
+        <div class="source-type-select">
             <v-select
                 :options="sourceTypeSelectOptions"
                 :reduce="option => option.value"
@@ -14,7 +12,7 @@
         </div>
 
         <div class="flex-1">
-            <div v-if="source === 'inherit'" class="text-sm text-grey inherit-placeholder mt-1">
+            <div v-if="source === 'inherit'" class="text-sm text-grey inherit-placeholder">
                 <template v-if="placeholder !== false">
                     {{ placeholder }}
                 </template>
@@ -45,9 +43,19 @@
         width: 20rem;
     }
 
-    .inherit-placeholder {
-        padding-top: 5px;
-    }
+	.inherit-placeholder {
+		padding-top: 5px;
+	}
+
+	@container live-preview (max-width: 895px) {
+	    .source-container {
+		    flex-direction: column !important;
+	    }
+
+	    .source-type-select {
+		    width: 100%;
+	    }
+	}
 
     .source-field-select .selectize-dropdown,
     .source-field-select .selectize-input span {


### PR DESCRIPTION
This pull request fixes some display issues with SEO Pro's fields in Live Preview. We can clean this up during the v6 UI refresh.

Fixes #309.

## Before

<img width="484" height="843" alt="CleanShot 2025-09-25 at 17 48 09" src="https://github.com/user-attachments/assets/065a938c-b673-4e0e-8918-fa33fbf81354" />


## After

<img width="484" height="843" alt="CleanShot 2025-09-25 at 17 47 06" src="https://github.com/user-attachments/assets/aff32ac6-f986-4355-be57-6c72779fd746" />
