### PR TITLE
`home_url` should use site's absolute URL, not app URL

### DIFF
--- a/src/Cascade.php
+++ b/src/Cascade.php
@@ -93,7 +93,7 @@ class Cascade
             'canonical_url' => $this->canonicalUrl(),
             'prev_url' => $this->prevUrl(),
             'next_url' => $this->nextUrl(),
-            'home_url' => Str::removeRight(URL::makeAbsolute('/'), '/'),
+            'home_url' => Str::removeRight(Site::current()?->absoluteUrl() ?? URL::makeAbsolute('/'), '/'),
             'humans_txt' => $this->humans(),
             'site' => $this->site(),
             'alternate_locales' => $alternateLocales = $this->alternateLocales(),


### PR DESCRIPTION
This pull request ensures that `home_url` uses the site's absolute URL (from `resources/sites.yaml`), rather than the app URL.

This was mostly an issue on headless sites - where the CMS is running on a different domain than the configured site.

Fixes #332