### PR TITLE
Convert PHPUnit annotations to attributes

### DIFF
--- a/tests/CascadeTest.php
+++ b/tests/CascadeTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Config;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Site;
@@ -19,7 +21,7 @@ class CascadeTest extends TestCase
         parent::tearDown();
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_seo_cascade_from_site_defaults_and_home_entry()
     {
         $data = (new Cascade)
@@ -50,7 +52,7 @@ class CascadeTest extends TestCase
         $this->assertArraySubset($expected, $data);
     }
 
-    /** @test */
+    #[Test]
     public function it_overwrites_data_in_cascade()
     {
         $data = (new Cascade)
@@ -89,7 +91,7 @@ class CascadeTest extends TestCase
         $this->assertArraySubset($expected, $data);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_compiled_title_from_cascaded_parts()
     {
         $data = (new Cascade)
@@ -108,7 +110,7 @@ class CascadeTest extends TestCase
         $this->assertEquals('Cool Writings >>> Jamaica', $data['compiled_title']);
     }
 
-    /** @test */
+    #[Test]
     public function it_parses_antlers()
     {
         $entry = Entry::findByUri('/about')->entry();
@@ -148,11 +150,8 @@ class CascadeTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider phpInAntlersProvider
-     */
+    #[Test]
+    #[DataProvider('phpInAntlersProvider')]
     public function it_doesnt_parse_php_in_antlers($antlers, $output)
     {
         $entry = Entry::findByUri('/about')->entry();
@@ -169,7 +168,7 @@ class CascadeTest extends TestCase
         $this->assertEquals($output, $data['description']);
     }
 
-    /** @test */
+    #[Test]
     public function it_parses_field_references()
     {
         $entry = Entry::findByUri('/about')->entry();
@@ -187,7 +186,7 @@ class CascadeTest extends TestCase
         $this->assertEquals('Red', $data['description']);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_seo_cascade_without_exception_when_no_home_entry_exists()
     {
         Entry::findByUri('/')->delete();
@@ -220,7 +219,7 @@ class CascadeTest extends TestCase
         $this->assertArraySubset($expected, $data);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_404_title_with_404_in_response_code_in_context()
     {
         $data = (new Cascade)
@@ -234,7 +233,7 @@ class CascadeTest extends TestCase
         $this->assertEquals('404 Page Not Found | Site Name', $data['compiled_title']);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_seo_cascade_from_custom_site_defaults_path()
     {
         $this->files->put(base_path('custom_seo.yaml'), <<<'EOT'

--- a/tests/GraphQLTest.php
+++ b/tests/GraphQLTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Data;
 
@@ -36,7 +37,7 @@ class GraphQLTest extends TestCase
             ]);
     }
 
-    /** @test */
+    #[Test]
     public function it_queries_for_entry_seo_meta_html()
     {
         $query = <<<'GQL'
@@ -87,7 +88,7 @@ GQL;
             ]]);
     }
 
-    /** @test */
+    #[Test]
     public function it_queries_for_entry_seo_cascade_so_user_can_render_custom_meta()
     {
         $query = <<<'GQL'
@@ -159,7 +160,7 @@ GQL;
             ]]);
     }
 
-    /** @test */
+    #[Test]
     public function it_queries_for_term_seo_meta_html()
     {
         $query = <<<'GQL'
@@ -201,7 +202,7 @@ GQL;
             ]]);
     }
 
-    /** @test */
+    #[Test]
     public function it_queries_for_term_seo_cascade_so_user_can_render_custom_meta()
     {
         $query = <<<'GQL'
@@ -270,7 +271,7 @@ GQL;
             ]]);
     }
 
-    /** @test */
+    #[Test]
     public function it_gracefully_outputs_null_image_when_not_set()
     {
         $query = <<<'GQL'

--- a/tests/HumansTest.php
+++ b/tests/HumansTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests;
 
+use Orchestra\Testbench\Attributes\DefineEnvironment;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Config;
 
 class HumansTest extends TestCase
@@ -17,7 +19,7 @@ class HumansTest extends TestCase
         $this->files->makeDirectory($folder, 0755, true);
     }
 
-    /** @test */
+    #[Test]
     public function it_outputs_humans_txt()
     {
         $content = $this
@@ -47,7 +49,7 @@ EOT;
         $this->assertEquals($expected, $content);
     }
 
-    /** @test */
+    #[Test]
     public function it_404s_when_humans_txt_is_disabled()
     {
         Config::set('statamic.seo-pro.humans.enabled', false);
@@ -57,7 +59,7 @@ EOT;
             ->assertStatus(404);
     }
 
-    /** @test */
+    #[Test]
     public function it_outputs_humans_txt_with_altered_site_defaults()
     {
         $this->setSeoInSiteDefaults([
@@ -75,11 +77,8 @@ EOT;
         $this->assertStringContainsStringIgnoringLineEndings('Description: Bob sled team!', $content);
     }
 
-    /**
-     * @test
-     *
-     * @environment-setup setCustomHumansTxtUrl
-     */
+    #[Test]
+    #[DefineEnvironment('setCustomHumansTxtUrl')]
     public function it_outputs_humans_txt_with_custom_url()
     {
         $this->setSeoInSiteDefaults([
@@ -99,7 +98,7 @@ EOT;
         $this->assertStringContainsStringIgnoringLineEndings('Creator: Cool Runnings', $content);
     }
 
-    /** @test */
+    #[Test]
     public function it_outputs_humans_txt_with_custom_view()
     {
         $this->setSeoInSiteDefaults([

--- a/tests/Localized/CascadeTest.php
+++ b/tests/Localized/CascadeTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Localized;
 
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Entry;
 use Statamic\SeoPro\Cascade;
 use Statamic\SeoPro\SiteDefaults;
@@ -19,7 +20,7 @@ class CascadeTest extends TestCase
         $app['config']->set('statamic.system.multisite', true);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_seo_cascade_for_canonical_url_and_alternate_locales()
     {
         $entry = Entry::findByUri('/about', 'italian')->entry();
@@ -38,7 +39,7 @@ class CascadeTest extends TestCase
         ], collect($data['alternate_locales'])->pluck('url', 'hreflang')->all());
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_seo_cascade_for_canonical_url_and_handles_duplicate_alternate_hreflangs()
     {
         $entry = Entry::findByUri('/', 'italian')->entry();
@@ -58,7 +59,7 @@ class CascadeTest extends TestCase
         ], collect($data['alternate_locales'])->pluck('url', 'hreflang')->all());
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_seo_cascade_for_canonical_url_and_handles_duplicate_current_hreflang()
     {
         $entry = Entry::findByUri('/', 'default')->entry();

--- a/tests/Localized/GraphQLTest.php
+++ b/tests/Localized/GraphQLTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Localized;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class GraphQLTest extends TestCase
@@ -18,7 +19,7 @@ class GraphQLTest extends TestCase
         $app['config']->set('statamic.graphql.resources.collections', true);
     }
 
-    /** @test */
+    #[Test]
     public function it_queries_multisite_for_canonical_url_and_alternate_locales_in_html_meta()
     {
         $query = <<<'GQL'
@@ -64,7 +65,7 @@ GQL;
             ]]);
     }
 
-    /** @test */
+    #[Test]
     public function it_queries_multisite_for_canonical_url_and_alternate_locales_in_cascade_meta()
     {
         $query = <<<'GQL'

--- a/tests/Localized/MetaTagTest.php
+++ b/tests/Localized/MetaTagTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Localized;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Config;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Site;
@@ -30,11 +32,8 @@ class MetaTagTest extends TestCase
         parent::tearDown();
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_generates_multisite_meta($viewType)
     {
         $this->prepareViews($viewType);
@@ -60,11 +59,8 @@ EOT;
         $this->assertStringContainsStringIgnoringLineEndings($expectedAlternateHreflangMeta, $content);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_generates_multisite_meta_for_non_home_page_route($viewType)
     {
         $this->prepareViews($viewType);
@@ -88,11 +84,8 @@ EOT;
         $this->assertStringContainsStringIgnoringLineEndings($expectedAlternateHreflangMeta, $content);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_doesnt_generate_multisite_meta_when_it_doesnt_exist_for_page($viewType)
     {
         $this->prepareViews($viewType);
@@ -104,11 +97,8 @@ EOT;
         $response->assertDontSee('hreflang', false);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_generates_multisite_meta_for_canonical_url_and_alternate_locales($viewType)
     {
         $this->prepareViews($viewType);
@@ -138,11 +128,8 @@ EOT;
         $this->assertStringContainsStringIgnoringLineEndings($expectedAlternateHreflangMeta, $content);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_handles_duplicate_alternate_hreflangs($viewType)
     {
         $this->prepareViews($viewType);
@@ -166,11 +153,8 @@ EOT;
         $this->assertStringContainsStringIgnoringLineEndings($expectedAlternateHreflangMeta, $content);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_handles_duplicate_current_hreflang($viewType)
     {
         $this->prepareViews($viewType);
@@ -194,11 +178,8 @@ EOT;
         $this->assertStringContainsStringIgnoringLineEndings($expectedAlternateHreflangMeta, $content);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_doesnt_generate_multisite_meta_when_alternate_locales_are_disabled($viewType)
     {
         Config::set('statamic.seo-pro.alternate_locales', false);
@@ -212,11 +193,8 @@ EOT;
         $response->assertDontSee('hreflang', false);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_doesnt_generate_multisite_meta_for_excluded_sites($viewType)
     {
         Config::set('statamic.seo-pro.alternate_locales.excluded_sites', ['french']);
@@ -242,11 +220,8 @@ EOT;
         $this->assertStringNotContainsStringIgnoringLineEndings('hreflang="fr"', $content);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_doesnt_generate_multisite_meta_for_unpublished_content($viewType)
     {
         $this->prepareViews($viewType);
@@ -270,11 +245,8 @@ EOT;
         $this->assertStringContainsStringIgnoringLineEndings($expectedAlternateHreflangMeta, $content);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_doesnt_generate_multisite_meta_for_scheduled_content($viewType)
     {
         $this->prepareViews($viewType);
@@ -304,11 +276,8 @@ EOT;
         $this->assertStringContainsStringIgnoringLineEndings($expectedAlternateHreflangMeta, $content);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_doesnt_generate_multisite_meta_for_expired_content($viewType)
     {
         $this->prepareViews($viewType);

--- a/tests/MetaTagTest.php
+++ b/tests/MetaTagTest.php
@@ -6,6 +6,9 @@ use Facades\Statamic\View\Cascade as StatamicViewCacade;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\Attributes\DefineEnvironment;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Extensions\Pagination\LengthAwarePaginator as StatamicLengthAwarePaginator;
 use Statamic\Facades\Asset;
 use Statamic\Facades\Blink;
@@ -54,11 +57,8 @@ class MetaTagTest extends TestCase
         parent::tearDown();
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_generates_normalized_meta($viewType)
     {
         $this->prepareViews($viewType);
@@ -86,11 +86,8 @@ EOT;
         $this->assertStringContainsStringIgnoringLineEndings($this->normalizeMultilineString($expected), $content);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_generates_normalized_meta_when_visiting_statamic_route_with_raw_view_data($viewType)
     {
         $this->prepareViews($viewType);
@@ -117,11 +114,8 @@ EOT;
         $this->assertStringContainsStringIgnoringLineEndings($this->normalizeMultilineString($expected), $content);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_generates_normalized_meta_when_visiting_statamic_route_with_raw_data_when_no_fallback_entry_exists($viewType)
     {
         Entry::findByUri('/')->deleteQuietly();
@@ -150,11 +144,8 @@ EOT;
         $this->assertStringContainsStringIgnoringLineEndings($this->normalizeMultilineString($expected), $content);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_doesnt_generate_meta_when_seo_is_disabled_on_collection($viewType)
     {
         $this
@@ -168,11 +159,8 @@ EOT;
         $response->assertDontSee('<link', false);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_doesnt_generate_meta_when_seo_is_disabled_on_entry($viewType)
     {
         $this
@@ -186,11 +174,8 @@ EOT;
         $response->assertDontSee('<link', false);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_generates_compiled_title_meta($viewType)
     {
         $this
@@ -206,11 +191,8 @@ EOT;
         $response->assertSee('<title>Site Name &gt;&gt;&gt; Aboot</title>', false);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_uses_cascade_to_generate_meta($viewType)
     {
         $this
@@ -232,11 +214,8 @@ EOT;
         $response->assertSee('<title>Cool Runnings -- Aboot</title>', false);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_generates_sanitized_title($viewType)
     {
         $this
@@ -254,11 +233,8 @@ EOT;
         $response->assertSee('<meta property="og:title" content="It&#039;s a me, Mario!" />', false);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_generates_sanitized_description($viewType)
     {
         $this
@@ -273,11 +249,8 @@ EOT;
         $response->assertSee('<meta property="og:description" content="It&#039;s a me, Mario!" />', false);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_generates_custom_twitter_card_with_short_summary($viewType)
     {
         $this->prepareViews($viewType);
@@ -289,11 +262,8 @@ EOT;
         $response->assertSee('<meta name="twitter:card" content="summary" />', false);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_generates_twitter_handle_meta($viewType)
     {
         $this
@@ -314,11 +284,8 @@ EOT;
         $response->assertSee('<meta name="twitter:site" content="@itsluigi85" />', false);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_generates_social_image($viewType)
     {
         Config::set('statamic.seo-pro.assets.container', 'assets');
@@ -337,13 +304,9 @@ EOT;
         $response->assertSee('<meta name="twitter:image" content="http://cool-runnings.com/img/asset/YXNzZXRzL2ltZy9zdGV0c29uLmpwZw/stetson.jpg?p=seo_pro_twitter&s=095c80594c864bedc5c4c2cb2c83ee1c" />', false);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     *
-     * @environment-setup setNoGlidePresets
-     */
+    #[Test]
+    #[DefineEnvironment('setNoGlidePresets')]
+    #[DataProvider('viewScenarioProvider')]
     public function it_only_generates_one_social_image_when_the_field_is_an_array($viewType)
     {
         Config::set('statamic.seo-pro.assets.container', 'assets');
@@ -382,13 +345,9 @@ EOT;
 
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     *
-     * @environment-setup setCustomGlidePresetDimensions
-     */
+    #[Test]
+    #[DefineEnvironment('setCustomGlidePresetDimensions')]
+    #[DataProvider('viewScenarioProvider')]
     public function it_generates_social_image_with_custom_glide_presets($viewType)
     {
         Artisan::call('statamic:glide:clear');
@@ -406,13 +365,9 @@ EOT;
         $response->assertSee('<meta property="og:image:height" content="600" />', false);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     *
-     * @environment-setup setCustomOgGlidePresetOnly
-     */
+    #[Test]
+    #[DefineEnvironment('setCustomOgGlidePresetOnly')]
+    #[DataProvider('viewScenarioProvider')]
     public function it_generates_social_image_with_og_glide_preset_only($viewType)
     {
         Artisan::call('statamic:glide:clear');
@@ -431,13 +386,9 @@ EOT;
         $response->assertSee('<meta property="og:image:height" content="600" />', false);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     *
-     * @environment-setup setCustomTwitterGlidePresetOnly
-     */
+    #[Test]
+    #[DefineEnvironment('setCustomTwitterGlidePresetOnly')]
+    #[DataProvider('viewScenarioProvider')]
     public function it_generates_social_image_with_twitter_glide_preset_only($viewType)
     {
         Artisan::call('statamic:glide:clear');
@@ -454,11 +405,8 @@ EOT;
         $response->assertSee('<meta name="twitter:image" content="http://cool-runnings.com/img/asset/YXNzZXRzL2ltZy9zdGV0c29uLmpwZw/stetson.jpg?p=seo_pro_twitter&s=095c80594c864bedc5c4c2cb2c83ee1c" />', false);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_generates_home_url_for_entry_meta($viewType)
     {
         $this->prepareViews($viewType);
@@ -468,11 +416,8 @@ EOT;
         $response->assertSee('<link href="http://cool-runnings.com" rel="home" />', false);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_generates_canonical_url_for_entry_meta($viewType)
     {
         $this->prepareViews($viewType);
@@ -482,11 +427,8 @@ EOT;
         $response->assertSee('<link href="http://cool-runnings.com/about" rel="canonical" />', false);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_generates_canonical_url_for_term_meta($viewType)
     {
         $this->prepareViews($viewType);
@@ -496,11 +438,8 @@ EOT;
         $response->assertSee('<link href="http://cool-runnings.com/topics/sneakers" rel="canonical" />', false);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_generates_canonical_url_meta_with_pagination($viewType)
     {
         $this->prepareViews($viewType);
@@ -510,11 +449,8 @@ EOT;
         $response->assertSee('<link href="http://cool-runnings.com/about?page=2" rel="canonical" />', false);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_generates_canonical_url_meta_without_pagination($viewType)
     {
         Config::set('statamic.seo-pro.pagination.enabled_in_canonical_url', false);
@@ -526,11 +462,8 @@ EOT;
         $response->assertSee('<link href="http://cool-runnings.com/about" rel="canonical" />', false);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_generates_rel_next_prev_url_meta($viewType)
     {
         $this->prepareViews($viewType);
@@ -553,11 +486,8 @@ EOT;
         $response->assertDontSee('rel="next"', false);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_generates_rel_next_prev_url_meta_with_first_page_enabled($viewType)
     {
         Config::set('statamic.seo-pro.pagination.enabled_on_first_page', true);
@@ -569,11 +499,8 @@ EOT;
         $response->assertSee('<link href="http://cool-runnings.com/about?page=1" rel="prev" />', false);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_doesnt_generate_rel_next_prev_url_meta_without_paginator($viewType)
     {
         $this->prepareViews($viewType);
@@ -584,11 +511,8 @@ EOT;
         $response->assertDontSee('rel="prev"', false);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_doesnt_generate_any_pagination_when_completely_disabled($viewType)
     {
         Config::set('statamic.seo-pro.pagination', false);
@@ -602,11 +526,8 @@ EOT;
         $response->assertDontSee('rel="prev"', false);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_generates_canonical_url_meta_with_custom_url($viewType)
     {
         $this
@@ -620,11 +541,8 @@ EOT;
         $response->assertSee('<link href="https://hot-walkings.com/pages/aboot" rel="canonical" />', false);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_applies_pagination_to_custom_canonical_url_on_same_domain($viewType)
     {
         $this
@@ -638,11 +556,9 @@ EOT;
         $response->assertSee('<link href="http://cool-runnings.com/pages/aboot?page=2" rel="canonical" />', false);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+
+    #[DataProvider('viewScenarioProvider')]
     public function it_doesnt_apply_pagination_to_external_custom_canonical_url($viewType)
     {
         $this
@@ -656,11 +572,9 @@ EOT;
         $response->assertSee('<link href="https://hot-walkings.com/pages/aboot" rel="canonical" />', false);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+
+    #[DataProvider('viewScenarioProvider')]
     public function it_doesnt_apply_pagination_to_first_page($viewType)
     {
         $this->prepareViews($viewType);
@@ -670,11 +584,8 @@ EOT;
         $response->assertSee('<link href="http://cool-runnings.com/about" rel="canonical" />', false);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_can_apply_pagination_to_first_page_when_configured_as_unique_page($viewType)
     {
         Config::set('statamic.seo-pro.pagination.enabled_on_first_page', true);
@@ -686,13 +597,8 @@ EOT;
         $response->assertSee('<link href="http://cool-runnings.com/about?page=1" rel="canonical" />', false);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     *
-     * @environment-setup useFakeSsgPaginator
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_applies_custom_pagination_routing_to_meta_urls($viewType)
     {
         $this->withoutExceptionHandling();
@@ -705,11 +611,8 @@ EOT;
         $response->assertSee('<link href="http://cool-runnings.com/about/page/4" rel="next" />', false);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_generates_robots_meta($viewType)
     {
         $this->prepareViews($viewType);
@@ -736,11 +639,8 @@ EOT;
         $response->assertSee('<meta name="robots" content="noindex, nofollow" />', false);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_generates_custom_humans_url($viewType)
     {
         Config::set('statamic.seo-pro.humans.url', 'aliens.md');
@@ -752,11 +652,8 @@ EOT;
         $response->assertSee('<link type="text/plain" rel="author" href="http://cool-runnings.com/aliens.md" />', false);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_generates_search_engine_verification_codes($viewType)
     {
         $this
@@ -772,11 +669,8 @@ EOT;
         $response->assertSee('<meta name="msvalidate.01" content="bing123" />', false);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_generates_proper_404_page_title($viewType)
     {
         $this->prepareViews($viewType);
@@ -791,11 +685,8 @@ EOT;
         $this->assertStringContainsStringIgnoringLineEndings($this->normalizeMultilineString($expected), $content);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_generates_normalized_meta_from_custom_site_defaults_path($viewType)
     {
         $this->files->put(base_path('custom_seo.yaml'), <<<'EOT'
@@ -837,11 +728,8 @@ EOT;
         $this->assertStringContainsStringIgnoringLineEndings($this->normalizeMultilineString($expected), $content);
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider viewScenarioProvider
-     */
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_hydrates_cascade_on_custom_routes_using_blade_directive($viewType)
     {
         if ($viewType === 'antlers') {
@@ -855,7 +743,7 @@ EOT;
         $this->assertStringContainsStringIgnoringLineEndings('<title>Custom Route Entry Title | Site Name</title>', $content);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_loop_over_meta_data()
     {
         $this->withoutExceptionHandling();
@@ -874,7 +762,7 @@ EOT);
         $this->assertStringContainsStringIgnoringLineEndings('<h3>http://cool-runnings.com/the-view</h3>', $content);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_loop_over_aliased_meta_data()
     {
         $this->withoutExceptionHandling();
@@ -903,7 +791,7 @@ EOT);
         $this->assertStringContainsStringIgnoringLineEndings('<h3 class="canonical_url_without_scoping"></h3>', $content);
     }
 
-    /** @test */
+    #[Test]
     public function it_doesnt_output_canonical_when_robots_noindex()
     {
         $this

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -3,6 +3,7 @@
 namespace Tests;
 
 use Illuminate\Support\Carbon;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Config;
 use Statamic\Facades\Entry;
@@ -26,7 +27,7 @@ class ReportTest extends TestCase
         }
     }
 
-    /** @test */
+    #[Test]
     public function it_can_save_pending_report()
     {
         $this->assertFileDoesNotExist($this->reportsPath());
@@ -51,7 +52,7 @@ EXPECTED;
         $this->assertEqualsIgnoringLineEndings($expected, $this->files->get($this->reportsPath('1/report.yaml')));
     }
 
-    /** @test */
+    #[Test]
     public function it_increments_report_folder_numbers()
     {
         $this->assertFileDoesNotExist($this->reportsPath());
@@ -66,7 +67,7 @@ EXPECTED;
         $this->assertFileExists($this->reportsPath('3'));
     }
 
-    /** @test */
+    #[Test]
     public function it_can_generate_a_report()
     {
         $this
@@ -100,7 +101,7 @@ EXPECTED;
         $this->assertCount(10, $this->files->allFiles($this->reportsPath('1/pages')));
     }
 
-    /** @test */
+    #[Test]
     public function it_doesnt_delete_old_reports_when_generating_by_default()
     {
         $this->generateEntries(1);
@@ -116,7 +117,7 @@ EXPECTED;
         $this->assertCount(17, $this->files->directories($this->reportsPath()));
     }
 
-    /** @test */
+    #[Test]
     public function it_doesnt_delete_old_reports_when_explicit_all_is_configured()
     {
         Config::set('statamic.seo-pro.reports.keep_recent', 'all');
@@ -134,7 +135,7 @@ EXPECTED;
         $this->assertCount(17, $this->files->directories($this->reportsPath()));
     }
 
-    /** @test */
+    #[Test]
     public function it_can_delete_old_reports_when_generating()
     {
         Config::set('statamic.seo-pro.reports.keep_recent', 13);
@@ -169,7 +170,7 @@ EXPECTED;
         $this->assertFileExists($this->reportsPath('17'));
     }
 
-    /** @test */
+    #[Test]
     public function it_properly_calculates_actionable_count()
     {
         $this
@@ -213,7 +214,7 @@ EXPECTED;
         $this->assertCount(10, $this->files->allFiles($this->reportsPath('1/pages')));
     }
 
-    /** @test */
+    #[Test]
     public function it_can_generate_a_large_report_with_multiple_chunked_jobs()
     {
         Config::set('statamic.seo-pro.reports.queue_chunk_size', 3);
@@ -257,7 +258,7 @@ EXPECTED;
         $this->assertCount(10, $this->files->allFiles($this->reportsPath('1/pages')));
     }
 
-    /** @test */
+    #[Test]
     public function it_skips_over_pages_with_disabled_seo()
     {
         $this
@@ -293,7 +294,7 @@ EXPECTED;
         $this->assertCount(9, $this->files->allFiles($this->reportsPath('1/pages')));
     }
 
-    /** @test */
+    #[Test]
     public function it_skips_over_entries_with_redirects()
     {
         $this->generateEntries(5);
@@ -327,7 +328,7 @@ EXPECTED;
         $this->assertCount(4, $this->files->allFiles($this->reportsPath('1/pages')));
     }
 
-    /** @test */
+    #[Test]
     public function it_properly_reports_on_unique_custom_title_values()
     {
         $this->generateEntries(5);
@@ -339,7 +340,7 @@ EXPECTED;
         $this->assertEqualsIgnoringLineEndings(0, $this->getReportResult('UniqueTitleTag'));
     }
 
-    /** @test */
+    #[Test]
     public function it_properly_reports_on_unique_custom_description_values()
     {
         $this->generateEntries(5);

--- a/tests/SitemapTest.php
+++ b/tests/SitemapTest.php
@@ -3,6 +3,8 @@
 namespace Tests;
 
 use Illuminate\Support\Collection as IlluminateCollection;
+use Orchestra\Testbench\Attributes\DefineEnvironment;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Console\Composer\Lock;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Collection;
@@ -24,7 +26,7 @@ class SitemapTest extends TestCase
         $this->files->makeDirectory($folder, 0755, true);
     }
 
-    /** @test */
+    #[Test]
     public function it_outputs_sitemap_xml()
     {
         $content = $this
@@ -97,7 +99,7 @@ EOT;
         $this->assertEquals($expected, $content);
     }
 
-    /** @test */
+    #[Test]
     public function it_404s_when_sitemap_xml_is_disabled()
     {
         Config::set('statamic.seo-pro.sitemap.enabled', false);
@@ -107,11 +109,8 @@ EOT;
             ->assertStatus(404);
     }
 
-    /**
-     * @test
-     *
-     * @environment-setup setCustomSitemapXmlUrl
-     */
+    #[Test]
+    #[DefineEnvironment('setCustomSitemapXmlUrl')]
     public function it_outputs_sitemap_xml_with_custom_url()
     {
         $this
@@ -127,7 +126,7 @@ EOT;
         $this->assertStringContainsStringIgnoringLineEndings('<loc>http://cool-runnings.com</loc>', $content);
     }
 
-    /** @test */
+    #[Test]
     public function it_outputs_sitemap_xml_with_custom_view()
     {
         $this->files->put(resource_path('views/vendor/seo-pro/sitemap.antlers.html'), '{{ xml_header }} test');
@@ -141,7 +140,7 @@ EOT;
         $this->assertEquals('<?xml version="1.0" encoding="UTF-8"?> test', $content);
     }
 
-    /** @test */
+    #[Test]
     public function it_uses_cascade_to_generate_priorities()
     {
         $this
@@ -168,7 +167,7 @@ EOT;
         $this->assertEquals('0.1', $priorities->get('http://cool-runnings.com/dance'));
     }
 
-    /** @test */
+    #[Test]
     public function it_uses_cascade_to_generate_frequencies()
     {
         $this
@@ -195,7 +194,7 @@ EOT;
         $this->assertEquals('weekly', $frequencies->get('http://cool-runnings.com/dance'));
     }
 
-    /** @test */
+    #[Test]
     public function it_doesnt_generate_pages_for_content_without_uris()
     {
         $this->files->put(base_path('content/collections/articles.yaml'), 'route: null');
@@ -225,7 +224,7 @@ EOT;
         return collect($data['url']);
     }
 
-    /** @test */
+    #[Test]
     public function it_outputs_paginated_sitemap_index_xml()
     {
         config()->set('statamic.seo-pro.sitemap.pagination.enabled', true);
@@ -256,7 +255,7 @@ EOT;
         $this->assertEquals($expected, $content);
     }
 
-    /** @test */
+    #[Test]
     public function it_outputs_paginated_sitemap_page_xml()
     {
         config()->set('statamic.seo-pro.sitemap.pagination.enabled', true);
@@ -352,7 +351,7 @@ EOT;
         $this->assertEquals($expected, $content);
     }
 
-    /** @test */
+    #[Test]
     public function it_404s_on_invalid_pagination_urls()
     {
         config()->set('statamic.seo-pro.sitemap.pagination.enabled', true);
@@ -371,7 +370,7 @@ EOT;
             ->assertNotFound();
     }
 
-    /** @test */
+    #[Test]
     public function it_can_use_custom_sitemap_queries()
     {
         // Hacky/temporary version compare, because `reorder()` method we're using


### PR DESCRIPTION
This pull request converts PHPUnit annotations to the attribute syntax, as annotations have been deprecated and will be removed in future versions of PHPUnit.