### PR TITLE
Remove test skipping on older versions of Statamic

### DIFF
--- a/tests/SitemapTest.php
+++ b/tests/SitemapTest.php
@@ -375,13 +375,6 @@ EOT;
     #[Test]
     public function it_can_use_custom_sitemap_queries()
     {
-        // Hacky/temporary version compare, because `reorder()` method we're using
-        // in CustomSitemap class below requires 5.29.0+, and we don't want to
-        // increase minimum required Statamic version just for test setup
-        if (version_compare(ltrim(Lock::file(__DIR__.'/../composer.lock')->getInstalledVersion('statamic/cms'), 'v'), '5.29.0', '<')) {
-            $this->markTestSkipped();
-        }
-
         app()->bind(Sitemap::class, CustomSitemap::class);
 
         config()->set('statamic.seo-pro.sitemap.pagination.enabled', true);

--- a/tests/SitemapTest.php
+++ b/tests/SitemapTest.php
@@ -6,14 +6,12 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection as IlluminateCollection;
 use Orchestra\Testbench\Attributes\DefineEnvironment;
 use PHPUnit\Framework\Attributes\Test;
-use Statamic\Console\Composer\Lock;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Config;
 use Statamic\Facades\Entry;
 use Statamic\SeoPro\Sitemap\Page;
 use Statamic\SeoPro\Sitemap\Sitemap;
-use Statamic\Statamic;
 
 class SitemapTest extends TestCase
 {


### PR DESCRIPTION
This pull request removes a temporary fix used to skip a test on older versions of Statamic.

It was originally added so we didn't need to change the minimum version constraint for a single test. The minimum version has since been changed for other reasons.