### PR TITLE
Use correct endpoint for fetching report score on index page

### DIFF
--- a/resources/js/components/reporting/IndexScore.vue
+++ b/resources/js/components/reporting/IndexScore.vue
@@ -50,7 +50,7 @@ export default {
 
     methods: {
         updateScore() {
-            Statamic.$request.get(cp_url(`seo-pro/reports/${this.id}`)).then(response => {
+            Statamic.$request.get(cp_url(`seo-pro/reports/${this.id}/pages`)).then(response => {
                 if (response.data.status === 'pending' || response.data.status === 'generating') {
                     setTimeout(() => this.updateScore(), 1000);
                     return;


### PR DESCRIPTION
This pull request corrects the URL used for fetching a report's score on the index page.

It was previously the `/cp/seo-pro/reports/{report}` route, but it changed in #314 to `/cp/seo-pro/reports/{report}/pages` and the JS was never updated.