### PR TITLE
Simplify `ServiceProvider`

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -9,7 +9,6 @@ use Statamic\Facades\GraphQL;
 use Statamic\Facades\Permission;
 use Statamic\Facades\User;
 use Statamic\Providers\AddonServiceProvider;
-use Statamic\SeoPro;
 
 class ServiceProvider extends AddonServiceProvider
 {


### PR DESCRIPTION
This pull request simplifies the addon's `ServiceProvider` now that tags, fieldtypes, widgets, routes and commands are auto-discovered by Statamic.