### PR TITLE
Fix `seo-pro:generate-report` command

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -134,7 +134,7 @@ class ServiceProvider extends AddonServiceProvider
     protected function bootAddonCommands()
     {
         $this->commands([
-            SeoPro\Commands\GenerateReportCommand::class,
+            Commands\GenerateReportCommand::class,
         ]);
 
         return $this;


### PR DESCRIPTION
This pull request fixes an issue where the `php please seo-pro:generate-report` command wasn't being registered on web requests, causing an error when attempting to run a report via the Control Panel:

<img width="977" height="956" alt="CleanShot 2025-10-17 at 10 16 32" src="https://github.com/user-attachments/assets/611e9a50-d526-4686-b237-f97acbb8d69e" />

This was caused by #433 because Statamic's auto-discovery of commands only happens when the application is running in the console.