### PR TITLE
Add full robots options to site defaults

### DIFF
--- a/src/SiteDefaults.php
+++ b/src/SiteDefaults.php
@@ -201,8 +201,13 @@ class SiteDefaults extends Collection
                                 'type' => 'select',
                                 'multiple' => true,
                                 'options' => [
+                                    'follow',
+                                    'index',
+                                    'noarchive',
+                                    'noimageindex',
                                     'noindex',
                                     'nofollow',
+                                    'nosnippet',
                                 ],
                                 'localizable' => true,
                             ],


### PR DESCRIPTION
This PR gives the same treatment to sitedefeaults robots as the section defaults got in https://github.com/statamic/seo-pro/pull/405

My mistake for not doing this initially.