### PR TITLE
Augment entry/term values before returning from REST API

### DIFF
--- a/src/Fieldtypes/SeoProFieldtype.php
+++ b/src/Fieldtypes/SeoProFieldtype.php
@@ -83,22 +83,11 @@ class SeoProFieldtype extends Fieldtype
 
     public function augment($data)
     {
-        if (Statamic::isApiRoute()) {
-            $content = $this->field()->parent();
-
-            return (new Cascade)
-                ->with(SiteDefaults::load()->augmented())
-                ->with($this->getAugmentedSectionDefaults($content))
-                ->with($data)
-                ->withCurrent($content)
-                ->get();
-        }
-
         if (empty($data) || ! is_iterable($data)) {
             return $data;
         }
 
-        return Blueprint::make()
+        $augmented = Blueprint::make()
             ->setContents(['fields' => $this->fieldConfig()])
             ->fields()
             ->addValues($data)
@@ -106,6 +95,19 @@ class SeoProFieldtype extends Fieldtype
             ->values()
             ->only(array_keys($data))
             ->all();
+
+        if (Statamic::isApiRoute()) {
+            $content = $this->field()->parent();
+
+            return (new Cascade)
+                ->with(SiteDefaults::load()->augmented())
+                ->with($this->getAugmentedSectionDefaults($content))
+                ->with($augmented)
+                ->withCurrent($content)
+                ->get();
+        }
+
+        return $augmented;
     }
 
     public function toGqlType()


### PR DESCRIPTION
This pull request fixes an issue where entry/term values weren't being augmented (like site & section defaults) before being returned by the REST API.

Fixes #446