### PR TITLE
[6.x] Avoid error when report rule class doesn't exist

### DIFF
--- a/src/Reporting/Page.php
+++ b/src/Reporting/Page.php
@@ -97,6 +97,11 @@ class Page
 
         foreach ($this->results as $class => $array) {
             $class = "Statamic\\SeoPro\\Reporting\\Rules\\$class";
+
+            if (! class_exists($class)) {
+                continue;
+            }
+
             $rule = new $class;
 
             if (! $rule->validatesPages()) {

--- a/src/Reporting/Report.php
+++ b/src/Reporting/Report.php
@@ -244,6 +244,10 @@ class Report implements Arrayable, Jsonable
         foreach ($results as $class => $result) {
             $class = "Statamic\\SeoPro\\Reporting\\Rules\\$class";
 
+            if (! class_exists($class)) {
+                continue;
+            }
+
             $rule = (new $class)->setReport($this);
 
             $rule->load($result);


### PR DESCRIPTION
This pull request fixes an issue where an error would occur if SEO Pro can't find the class for a report rule.

This means that if we add new rules to SEO Pro, you generate a report, then have to rollback for whatever reason, you'd get errors when accessing the Reports page or the Dashboard (if you're using the SEO Pro widget).

Spotted this myself when switching between v5 and v6 variants of this addon.