### PR TITLE
[6.x] Avoid infinite loop when "From Field" points to multiple non-existant fields

### DIFF
--- a/src/Cascade.php
+++ b/src/Cascade.php
@@ -228,8 +228,11 @@ class Cascade
         return URL::makeAbsolute($nextUrl);
     }
 
-    protected function parse($key, $item)
-    {
+    protected function parse(
+        string $key,
+        mixed $item,
+        bool $hasAttemptedToFallbackToSection = false
+    ) {
         $original = $item;
 
         if (is_array($item)) {
@@ -268,12 +271,16 @@ class Cascade
 
             // When the field is empty, attempt to fall back to the section or site defaults.
             if (! $item) {
-                if (isset($this->sectionDefaults[$key]) && $this->sectionDefaults[$key] !== $original) {
-                    return $this->parse($key, $this->sectionDefaults[$key]);
+                if (
+                    ! $hasAttemptedToFallbackToSection
+                    && isset($this->sectionDefaults[$key])
+                    && $this->sectionDefaults[$key] !== $original
+                ) {
+                    return $this->parse($key, $this->sectionDefaults[$key], hasAttemptedToFallbackToSection: true);
                 }
 
                 if (isset($this->siteDefaults[$key]) && $this->siteDefaults[$key] !== $original) {
-                    return $this->parse($key, $this->siteDefaults[$key]);
+                    return $this->parse($key, $this->siteDefaults[$key], $hasAttemptedToFallbackToSection);
                 }
             }
         }


### PR DESCRIPTION
#456 ensured that when an entry's "From Field" field is empty, it would fallback to the section or site default, whichever is available instead of remaining empty.

**Example:** if the social image for a collection/section is set to a "Thumbnail", but its empty, it should use the social image defined in the site defaults.

This pull request fixes an issue where you might end up in an infinite loop if the entry, section and site defaults are empty, as SEO Pro attempts to go between them, in circles.

Fixes #469