### PR TITLE
[7.x] Add min-width on dropdowns

### DIFF
--- a/resources/js/components/fieldtypes/SourceFieldtype.vue
+++ b/resources/js/components/fieldtypes/SourceFieldtype.vue
@@ -90,7 +90,7 @@ const metaPathPrefix = computed(() => {
 
 <template>
     <div class="flex flex-col md:flex-row md:items-center @max-lg/live-preview:!flex-col @max-lg/live-preview:!items-start gap-2 border border-gray-200 rounded-md p-2 bg-gray-50 dark:bg-gray-900 dark:border-gray-800">
-        <div class="w-32">
+        <div class="w-auto min-w-32">
             <Select
 	            class="w-full"
                 :options="sourceTypeSelectOptions"


### PR DESCRIPTION
If I did this right, it should add min-with to every dropdown like the solution implemented in https://github.com/statamic/cms/pull/13289. (The screenshots are only from a simulation with the browser inspect tool.)

Despite there is now sometimes a little less space for the input field to the right, it makes SEO Pro in German much more readable on the first place.

## Before
<img width="1066" height="1266" alt="Bildschirmfoto 2025-12-10 um 16 27 32" src="https://github.com/user-attachments/assets/b7400034-a966-4b9d-8206-ab86a0738531" />

## After
<img width="1046" height="1374" alt="Bildschirmfoto 2025-12-10 um 16 30 00" src="https://github.com/user-attachments/assets/fc014b34-cbd3-45d3-9a25-b89b3d6619ea" />
