### PR TITLE
[7.x] Fix dark mode issues in Page Details modal

### DIFF
--- a/resources/js/components/reporting/PageDetailsModal.vue
+++ b/resources/js/components/reporting/PageDetailsModal.vue
@@ -25,11 +25,11 @@ const close = () => {
 		    <div
 		        v-for="item in page.results"
 		        class="flex leading-normal p-2 rounded-lg gap-x-3"
-		        :class="{ 'bg-red-50 dark:bg-dark-400': item.status !== 'pass' }"
+		        :class="{ 'bg-red-50 dark:!bg-dark-400': item.status !== 'pass' }"
 		    >
 			    <StatusIcon :status="item.status" class="mt-1" />
 			    <div class="flex-1 prose text-gray-700">
-				    <Heading size="sm" class="text-gray-900 dark:text-dark-100" :text="item.description" />
+				    <Heading size="sm" class="text-gray-900 dark:!text-dark-100" :text="item.description" />
 				    <Description :class="{ 'text-red-500': item.status !== 'pass' }" v-if="item.comment" :text="item.comment" />
 			    </div>
 		    </div>
@@ -37,7 +37,7 @@ const close = () => {
 
 	    <template #footer>
 		    <div class="flex items-center justify-between pt-3 pb-1">
-			    <a v-if="page.url" :href="page.url" target="_blank" class="font-normal font-mono text-xs ps-2 text-gray-700 hover:text-blue-500! grow truncate" v-text="page.url" />
+			    <a v-if="page.url" :href="page.url" target="_blank" class="font-normal font-mono text-xs ps-2 text-gray-700 dark:!text-gray-100 hover:text-blue-500! grow truncate" v-text="page.url" />
                 <Button v-if="page.edit_url" :href="page.edit_url" target="_blank" :text="__('Edit Entry')" />
 		    </div>
 	    </template>


### PR DESCRIPTION
This pull request fixes some dark mode issues in the Page Details modal. The light mode classes from Statamic's CSS file were stomping over the dark mode classes from SEO Pro's CSS file. 

The easiest solution is to mark the classes as important so they take precedence. It's probably not the "right" solution, but it'll work for now.

Fixes #465

## Before

<img width="1404" height="1090" alt="image" src="https://github.com/user-attachments/assets/2a75a0d1-d5e4-45e5-b325-f0f4b2294bdf" />

## After

<img width="683" height="593" alt="image" src="https://github.com/user-attachments/assets/acd49806-f5d8-48f0-8046-0254b3b11341" />