### PR TITLE
Harden SourceFieldtype process method

### DIFF
--- a/src/Fieldtypes/SourceFieldtype.php
+++ b/src/Fieldtypes/SourceFieldtype.php
@@ -49,7 +49,7 @@ class SourceFieldtype extends Fieldtype
 
     public function process($data)
     {
-        if (!is_array($data) || !isset($data['source'])) {
+        if (! is_array($data) || ! isset($data['source'])) {
             return null;
         }
 


### PR DESCRIPTION
This PR adds extra $data validation to SourceFieldtypes process method.

Additional info:
Perhaps i have a special usecase: We only want to offer a subset of seo pro fields for entries. So i removed some Fields from the config [ Statamic\SeoPro\Fields - getConfig() ]. After that i  got a type error in SourceFieldtypes process method.

Perhaps it makes sense to make field selection configurable in the future?