### PR TITLE
Fix disabled SEO fields (again!)

### DIFF
--- a/resources/js/components/fieldtypes/SeoProFieldtype.vue
+++ b/resources/js/components/fieldtypes/SeoProFieldtype.vue
@@ -12,7 +12,7 @@ const { originValues } = injectPublishContext();
 
 const readOnly = computed(() => {
 	// When localizing an entry AND "localizable" is disabled, make the fields read-only.
-	if (originValues !== null && !props.config.localizable) {
+	if (originValues?.length > 0 && !props.config.localizable) {
 		return true;
 	}
 
@@ -21,7 +21,7 @@ const readOnly = computed(() => {
 </script>
 
 <template>
-    <div>
+    <div :class="{ 'opacity-50': readOnly }">
 	    <FieldsProvider
 		    :fields="meta.fields"
 		    :read-only="readOnly"


### PR DESCRIPTION
This pull request fixes an issue where SEO fields on entries and terms were wrongly marked as disabled. I thought I had fixed it in #493, but obviously not. 😄

This PR also adds `opacity-50`, which is applied by Statamic when `isReadOnly` is true, but it doesn't apply to non-localisable fields.

Fixes #490
