### PR TITLE
Supports Laravel 13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,14 +16,14 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.3, 8.4]
-        laravel: [12.*]
+        php: [8.3, 8.4, 8.5]
+        laravel: [13.* 12.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         include:
           - os: windows-latest
-            php: 8.4
-            laravel: 12.*
+            php: 8.5
+            laravel: 13.*
             stability: prefer-stable
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         php: [8.3, 8.4, 8.5]
-        laravel: [13.* 12.*]
+        laravel: [13.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         include:

--- a/composer.json
+++ b/composer.json
@@ -33,9 +33,9 @@
     },
     "require-dev": {
         "orchestra/testbench": "^10.0",
-        "phpunit/phpunit": "^11.5.3",
+        "phpunit/phpunit": "^11.5.3 || ^12.0",
         "laravel/pint": "^1.17",
-        "spatie/laravel-ray": "^1.40"
+        "spatie/laravel-ray": "^1.43.6"
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "pixelfear/composer-dist-plugin": "^0.1.6"
     },
     "require-dev": {
-        "orchestra/testbench": "^10.0",
+        "orchestra/testbench": "^10.0 || ^11.0",
         "phpunit/phpunit": "^11.5.3 || ^12.0",
         "laravel/pint": "^1.17",
         "spatie/laravel-ray": "^1.43.6"

--- a/composer.json
+++ b/composer.json
@@ -41,5 +41,7 @@
         "allow-plugins": {
             "pixelfear/composer-dist-plugin": true
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         }
     },
     "require": {
-        "statamic/cms": "^6.4.1",
+        "statamic/cms": "^6.5",
         "pixelfear/composer-dist-plugin": "^0.1.6"
     },
     "require-dev": {


### PR DESCRIPTION
This pull request adds Laravel 13 support to SEO Pro. Laravel 13 is due to be released [Early March](https://x.com/taylorotwell/status/2021555106269831216).

This PR also adds PHP 8.5 to the testing matrix.

Depends on:
* [x] https://github.com/statamic/cms/pull/13870
