### PR TITLE
Default site name should be APP_NAME

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,6 +11,7 @@
     <env name="SESSION_DRIVER" value="array"/>
     <env name="QUEUE_DRIVER" value="sync"/>
     <env name="APP_URL" value="http://cool-runnings.com"/>
+    <env name="APP_NAME" value="SEO Pro"/>
     <env name="APP_KEY" value="base64:QeU8nSJFKtBB3Y9SdxH0U4xH/1rsFd4zNfOLTeK/DUw="/>
     <env name="DB_CONNECTION" value="sqlite"/>
     <env name="DB_DATABASE" value=":memory:"/>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,7 +11,7 @@
     <env name="SESSION_DRIVER" value="array"/>
     <env name="QUEUE_DRIVER" value="sync"/>
     <env name="APP_URL" value="http://cool-runnings.com"/>
-    <env name="APP_NAME" value="SEO Pro"/>
+    <env name="APP_NAME" value="Cool Runnings"/>
     <env name="APP_KEY" value="base64:QeU8nSJFKtBB3Y9SdxH0U4xH/1rsFd4zNfOLTeK/DUw="/>
     <env name="DB_CONNECTION" value="sqlite"/>
     <env name="DB_DATABASE" value=":memory:"/>

--- a/src/SiteDefaults/SiteDefaults.php
+++ b/src/SiteDefaults/SiteDefaults.php
@@ -79,7 +79,7 @@ class SiteDefaults
     private static function defaultValues(): array
     {
         return [
-            'site_name' => 'Site Name',
+            'site_name' => '{{ config:app:name }}',
             'site_name_position' => 'after',
             'site_name_separator' => '|',
             'title' => '@seo:title',

--- a/tests/CascadeTest.php
+++ b/tests/CascadeTest.php
@@ -30,7 +30,7 @@ class CascadeTest extends TestCase
             ->get();
 
         $expected = [
-            'site_name' => 'Site Name',
+            'site_name' => 'SEO Pro',
             'site_name_position' => 'after',
             'site_name_separator' => '|',
             'title' => 'Home',
@@ -199,7 +199,7 @@ class CascadeTest extends TestCase
             ->get();
 
         $expected = [
-            'site_name' => 'Site Name',
+            'site_name' => 'SEO Pro',
             'site_name_position' => 'after',
             'site_name_separator' => '|',
             'title' => null,

--- a/tests/CascadeTest.php
+++ b/tests/CascadeTest.php
@@ -37,7 +37,7 @@ class CascadeTest extends TestCase
             'description' => 'I see a bad-ass mother.',
             'priority' => 0.5,
             'change_frequency' => 'monthly',
-            'compiled_title' => 'Home | Site Name',
+            'compiled_title' => 'Home | SEO Pro',
             'og_title' => 'Home',
             'canonical_url' => 'http://cool-runnings.com',
             'prev_url' => null,
@@ -206,8 +206,8 @@ class CascadeTest extends TestCase
             'description' => null,
             'priority' => 0.5,
             'change_frequency' => 'monthly',
-            'compiled_title' => 'Site Name',
-            'og_title' => 'Site Name',
+            'compiled_title' => 'SEO Pro',
+            'og_title' => 'SEO Pro',
             'canonical_url' => 'http://cool-runnings.com',
             'prev_url' => null,
             'next_url' => null,
@@ -233,7 +233,7 @@ class CascadeTest extends TestCase
             ->get();
 
         $this->assertEquals('404 Page Not Found', $data['title']);
-        $this->assertEquals('404 Page Not Found | Site Name', $data['compiled_title']);
+        $this->assertEquals('404 Page Not Found | SEO Pro', $data['compiled_title']);
     }
 
     #[Test]

--- a/tests/CascadeTest.php
+++ b/tests/CascadeTest.php
@@ -30,14 +30,14 @@ class CascadeTest extends TestCase
             ->get();
 
         $expected = [
-            'site_name' => 'SEO Pro',
+            'site_name' => 'Cool Runnings',
             'site_name_position' => 'after',
             'site_name_separator' => '|',
             'title' => 'Home',
             'description' => 'I see a bad-ass mother.',
             'priority' => 0.5,
             'change_frequency' => 'monthly',
-            'compiled_title' => 'Home | SEO Pro',
+            'compiled_title' => 'Home | Cool Runnings',
             'og_title' => 'Home',
             'canonical_url' => 'http://cool-runnings.com',
             'prev_url' => null,
@@ -199,15 +199,15 @@ class CascadeTest extends TestCase
             ->get();
 
         $expected = [
-            'site_name' => 'SEO Pro',
+            'site_name' => 'Cool Runnings',
             'site_name_position' => 'after',
             'site_name_separator' => '|',
             'title' => null,
             'description' => null,
             'priority' => 0.5,
             'change_frequency' => 'monthly',
-            'compiled_title' => 'SEO Pro',
-            'og_title' => 'SEO Pro',
+            'compiled_title' => 'Cool Runnings',
+            'og_title' => 'Cool Runnings',
             'canonical_url' => 'http://cool-runnings.com',
             'prev_url' => null,
             'next_url' => null,
@@ -233,7 +233,7 @@ class CascadeTest extends TestCase
             ->get();
 
         $this->assertEquals('404 Page Not Found', $data['title']);
-        $this->assertEquals('404 Page Not Found | SEO Pro', $data['compiled_title']);
+        $this->assertEquals('404 Page Not Found | Cool Runnings', $data['compiled_title']);
     }
 
     #[Test]

--- a/tests/HumansTest.php
+++ b/tests/HumansTest.php
@@ -31,7 +31,7 @@ class HumansTest extends TestCase
         $expected = <<<'EOT'
 /* TEAM */
 
-Creator: Site Name
+Creator: SEO Pro
 URL: http://cool-runnings.com
 Description: I see a bad-ass mother.
 

--- a/tests/HumansTest.php
+++ b/tests/HumansTest.php
@@ -31,7 +31,7 @@ class HumansTest extends TestCase
         $expected = <<<'EOT'
 /* TEAM */
 
-Creator: SEO Pro
+Creator: Cool Runnings
 URL: http://cool-runnings.com
 Description: I see a bad-ass mother.
 

--- a/tests/Localized/GraphQLTest.php
+++ b/tests/Localized/GraphQLTest.php
@@ -35,7 +35,7 @@ GQL;
             '<meta property="og:title" content="Les Nectar of the Gods" />',
             '<meta property="og:description" content="The day started just like any other. Wake up at 5:30am, brush my teeth, bathe in a tub of warm milk, and trim my toenails while quietly resenting the fact that Flipper was on Nickelodeon at this hour instead of Rocko&#039;s Modern Life. That would have to wait until 5:30pm for that, and I am impatient.In truth, the day wou..." />',
             '<meta property="og:url" content="http://cool-runnings.com/fr/nectar" />',
-            '<meta property="og:site_name" content="Site Name" />',
+            '<meta property="og:site_name" content="SEO Pro" />',
             '<meta property="og:locale" content="fr_FR" />',
             '<meta property="og:locale:alternate" content="en_US" />',
             '<meta name="twitter:card" content="summary_large_image" />',

--- a/tests/Localized/GraphQLTest.php
+++ b/tests/Localized/GraphQLTest.php
@@ -29,13 +29,13 @@ class GraphQLTest extends LocalizedTestCase
 GQL;
 
         $expectedHtml = collect([
-            '<title>Les Nectar of the Gods | SEO Pro</title>',
+            '<title>Les Nectar of the Gods | Cool Runnings</title>',
             '<meta name="description" content="The day started just like any other. Wake up at 5:30am, brush my teeth, bathe in a tub of warm milk, and trim my toenails while quietly resenting the fact that Flipper was on Nickelodeon at this hour instead of Rocko&#039;s Modern Life. That would have to wait until 5:30pm for that, and I am impatient.In truth, the day wou..." />',
             '<meta property="og:type" content="website" />',
             '<meta property="og:title" content="Les Nectar of the Gods" />',
             '<meta property="og:description" content="The day started just like any other. Wake up at 5:30am, brush my teeth, bathe in a tub of warm milk, and trim my toenails while quietly resenting the fact that Flipper was on Nickelodeon at this hour instead of Rocko&#039;s Modern Life. That would have to wait until 5:30pm for that, and I am impatient.In truth, the day wou..." />',
             '<meta property="og:url" content="http://cool-runnings.com/fr/nectar" />',
-            '<meta property="og:site_name" content="SEO Pro" />',
+            '<meta property="og:site_name" content="Cool Runnings" />',
             '<meta property="og:locale" content="fr_FR" />',
             '<meta property="og:locale:alternate" content="en_US" />',
             '<meta name="twitter:card" content="summary_large_image" />',

--- a/tests/Localized/GraphQLTest.php
+++ b/tests/Localized/GraphQLTest.php
@@ -29,7 +29,7 @@ class GraphQLTest extends LocalizedTestCase
 GQL;
 
         $expectedHtml = collect([
-            '<title>Les Nectar of the Gods | Site Name</title>',
+            '<title>Les Nectar of the Gods | SEO Pro</title>',
             '<meta name="description" content="The day started just like any other. Wake up at 5:30am, brush my teeth, bathe in a tub of warm milk, and trim my toenails while quietly resenting the fact that Flipper was on Nickelodeon at this hour instead of Rocko&#039;s Modern Life. That would have to wait until 5:30pm for that, and I am impatient.In truth, the day wou..." />',
             '<meta property="og:type" content="website" />',
             '<meta property="og:title" content="Les Nectar of the Gods" />',

--- a/tests/MetaTagTest.php
+++ b/tests/MetaTagTest.php
@@ -188,7 +188,7 @@ EOT;
 
         $response = $this->get('/about');
         $response->assertSee("<h1>{$viewType}</h1>", false);
-        $response->assertSee('<title>Site Name &gt;&gt;&gt; Aboot</title>', false);
+        $response->assertSee('<title>SEO Pro &gt;&gt;&gt; Aboot</title>', false);
     }
 
     #[Test]
@@ -828,7 +828,7 @@ EOT);
             ]);
 
         $response = $this->get('/about');
-        $response->assertSee('<title>Site Name | About Page 2</title>', false);
+        $response->assertSee('<title>SEO Pro | About Page 2</title>', false);
 
         $this
             ->prepareViews('antlers')

--- a/tests/MetaTagTest.php
+++ b/tests/MetaTagTest.php
@@ -70,7 +70,7 @@ class MetaTagTest extends TestCase
 <meta property="og:title" content="Home" />
 <meta property="og:description" content="I see a bad-ass mother." />
 <meta property="og:url" content="http://cool-runnings.com" />
-<meta property="og:site_name" content="Site Name" />
+<meta property="og:site_name" content="SEO Pro" />
 <meta property="og:locale" content="en_US" />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="Home" />
@@ -99,7 +99,7 @@ EOT;
 <meta property="og:title" content="The View" />
 <meta property="og:description" content="A wonderful view!" />
 <meta property="og:url" content="http://cool-runnings.com/the-view" />
-<meta property="og:site_name" content="Site Name" />
+<meta property="og:site_name" content="SEO Pro" />
 <meta property="og:locale" content="en_US" />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="The View" />
@@ -129,7 +129,7 @@ EOT;
 <meta property="og:title" content="The View" />
 <meta property="og:description" content="A wonderful view!" />
 <meta property="og:url" content="http://cool-runnings.com/the-view" />
-<meta property="og:site_name" content="Site Name" />
+<meta property="og:site_name" content="SEO Pro" />
 <meta property="og:locale" content="en_US" />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="The View" />

--- a/tests/MetaTagTest.php
+++ b/tests/MetaTagTest.php
@@ -64,13 +64,13 @@ class MetaTagTest extends TestCase
         $this->prepareViews($viewType);
 
         $expected = <<<'EOT'
-<title>Home | SEO Pro</title>
+<title>Home | Cool Runnings</title>
 <meta name="description" content="I see a bad-ass mother." />
 <meta property="og:type" content="website" />
 <meta property="og:title" content="Home" />
 <meta property="og:description" content="I see a bad-ass mother." />
 <meta property="og:url" content="http://cool-runnings.com" />
-<meta property="og:site_name" content="SEO Pro" />
+<meta property="og:site_name" content="Cool Runnings" />
 <meta property="og:locale" content="en_US" />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="Home" />
@@ -93,13 +93,13 @@ EOT;
         $this->prepareViews($viewType);
 
         $expected = <<<'EOT'
-<title>The View | SEO Pro</title>
+<title>The View | Cool Runnings</title>
 <meta name="description" content="A wonderful view!" />
 <meta property="og:type" content="website" />
 <meta property="og:title" content="The View" />
 <meta property="og:description" content="A wonderful view!" />
 <meta property="og:url" content="http://cool-runnings.com/the-view" />
-<meta property="og:site_name" content="SEO Pro" />
+<meta property="og:site_name" content="Cool Runnings" />
 <meta property="og:locale" content="en_US" />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="The View" />
@@ -123,13 +123,13 @@ EOT;
         $this->prepareViews($viewType);
 
         $expected = <<<'EOT'
-<title>The View | SEO Pro</title>
+<title>The View | Cool Runnings</title>
 <meta name="description" content="A wonderful view!" />
 <meta property="og:type" content="website" />
 <meta property="og:title" content="The View" />
 <meta property="og:description" content="A wonderful view!" />
 <meta property="og:url" content="http://cool-runnings.com/the-view" />
-<meta property="og:site_name" content="SEO Pro" />
+<meta property="og:site_name" content="Cool Runnings" />
 <meta property="og:locale" content="en_US" />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="The View" />
@@ -188,7 +188,7 @@ EOT;
 
         $response = $this->get('/about');
         $response->assertSee("<h1>{$viewType}</h1>", false);
-        $response->assertSee('<title>SEO Pro &gt;&gt;&gt; Aboot</title>', false);
+        $response->assertSee('<title>Cool Runnings &gt;&gt;&gt; Aboot</title>', false);
     }
 
     #[Test]
@@ -676,7 +676,7 @@ EOT;
         $this->prepareViews($viewType);
 
         $expected = <<<'EOT'
-<title>404 Page Not Found | SEO Pro</title>
+<title>404 Page Not Found | Cool Runnings</title>
 EOT;
 
         $content = $this->get('/non-existent-page')->content();
@@ -697,7 +697,7 @@ EOT;
 
         $content = $this->get('/custom-get-route')->content();
 
-        $this->assertStringContainsStringIgnoringLineEndings('<title>Custom Route Entry Title | SEO Pro</title>', $content);
+        $this->assertStringContainsStringIgnoringLineEndings('<title>Custom Route Entry Title | Cool Runnings</title>', $content);
     }
 
     #[Test]
@@ -819,7 +819,7 @@ EOT);
             ->setSeoOnEntry(Entry::findByUri('/about'), []);
 
         $response = $this->get('/about');
-        $response->assertSee('<title>About Page 2 | SEO Pro</title>', false);
+        $response->assertSee('<title>About Page 2 | Cool Runnings</title>', false);
 
         $this
             ->prepareViews('antlers')
@@ -828,7 +828,7 @@ EOT);
             ]);
 
         $response = $this->get('/about');
-        $response->assertSee('<title>SEO Pro | About Page 2</title>', false);
+        $response->assertSee('<title>Cool Runnings | About Page 2</title>', false);
 
         $this
             ->prepareViews('antlers')

--- a/tests/MetaTagTest.php
+++ b/tests/MetaTagTest.php
@@ -846,7 +846,7 @@ EOT);
             ->setSeoOnEntry(Entry::findByUri('/about'), []);
 
         $response = $this->get('/about');
-        $response->assertDontSee('<title>About Page 2 | SEO Pro</title>', false);
+        $response->assertDontSee('<title>About Page 2 | Cool Runnings</title>', false);
     }
 
     protected function setCustomGlidePresetDimensions($app)

--- a/tests/MetaTagTest.php
+++ b/tests/MetaTagTest.php
@@ -64,7 +64,7 @@ class MetaTagTest extends TestCase
         $this->prepareViews($viewType);
 
         $expected = <<<'EOT'
-<title>Home | Site Name</title>
+<title>Home | SEO Pro</title>
 <meta name="description" content="I see a bad-ass mother." />
 <meta property="og:type" content="website" />
 <meta property="og:title" content="Home" />
@@ -93,7 +93,7 @@ EOT;
         $this->prepareViews($viewType);
 
         $expected = <<<'EOT'
-<title>The View | Site Name</title>
+<title>The View | SEO Pro</title>
 <meta name="description" content="A wonderful view!" />
 <meta property="og:type" content="website" />
 <meta property="og:title" content="The View" />
@@ -123,7 +123,7 @@ EOT;
         $this->prepareViews($viewType);
 
         $expected = <<<'EOT'
-<title>The View | Site Name</title>
+<title>The View | SEO Pro</title>
 <meta name="description" content="A wonderful view!" />
 <meta property="og:type" content="website" />
 <meta property="og:title" content="The View" />
@@ -676,7 +676,7 @@ EOT;
         $this->prepareViews($viewType);
 
         $expected = <<<'EOT'
-<title>404 Page Not Found | Site Name</title>
+<title>404 Page Not Found | SEO Pro</title>
 EOT;
 
         $content = $this->get('/non-existent-page')->content();
@@ -697,7 +697,7 @@ EOT;
 
         $content = $this->get('/custom-get-route')->content();
 
-        $this->assertStringContainsStringIgnoringLineEndings('<title>Custom Route Entry Title | Site Name</title>', $content);
+        $this->assertStringContainsStringIgnoringLineEndings('<title>Custom Route Entry Title | SEO Pro</title>', $content);
     }
 
     #[Test]
@@ -819,7 +819,7 @@ EOT);
             ->setSeoOnEntry(Entry::findByUri('/about'), []);
 
         $response = $this->get('/about');
-        $response->assertSee('<title>About Page 2 | Site Name</title>', false);
+        $response->assertSee('<title>About Page 2 | SEO Pro</title>', false);
 
         $this
             ->prepareViews('antlers')
@@ -846,7 +846,7 @@ EOT);
             ->setSeoOnEntry(Entry::findByUri('/about'), []);
 
         $response = $this->get('/about');
-        $response->assertDontSee('<title>About Page 2 | Site Name</title>', false);
+        $response->assertDontSee('<title>About Page 2 | SEO Pro</title>', false);
     }
 
     protected function setCustomGlidePresetDimensions($app)

--- a/tests/SeoProFieldtypeTest.php
+++ b/tests/SeoProFieldtypeTest.php
@@ -81,6 +81,6 @@ class SeoProFieldtypeTest extends TestCase
 
         $this->assertEquals('Foo', (string) $augment['title']);
         $this->assertEquals('Bar', (string) $augment['description']);
-        $this->assertEquals('SEO Pro', (string) $augment['site_name']); // Site default
+        $this->assertEquals('Cool Runnings', (string) $augment['site_name']); // Site default
     }
 }

--- a/tests/SeoProFieldtypeTest.php
+++ b/tests/SeoProFieldtypeTest.php
@@ -81,6 +81,6 @@ class SeoProFieldtypeTest extends TestCase
 
         $this->assertEquals('Foo', (string) $augment['title']);
         $this->assertEquals('Bar', (string) $augment['description']);
-        $this->assertEquals('Site Name', (string) $augment['site_name']); // Site default
+        $this->assertEquals('SEO Pro', (string) $augment['site_name']); // Site default
     }
 }


### PR DESCRIPTION
The current default `site_name` is `'Site Name'`, but IMO it should be `{{ config:op:name }}` so that it's correct for many sites w/o configuration.