### PR TITLE
Allow disabling Glide for JSON-LD organization logo

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -120,6 +120,16 @@ You can even use Antlers to pull data from fields as necessary:
 
 ![JSON-LD Schema field on Section Defaults page](./docs-json-ld-schema.png)
 
+The "Organization Logo" will be dynamically resized using Glide to comply with the [JSON-LD schema](https://developers.google.com/search/docs/appearance/structured-data/organization). If you'd prefer to disable this behaviour, you may disable the `json_ld.use_glide_for_logo` option in your config.
+
+```php
+// config/statamic/seo-pro.php
+
+'json_ld' => [
+    'use_glide_for_logo' => false,
+],
+```
+
 ## Reports
 
 You may generate an SEO report that checks all the pages of your site against a number of tests. The tests include mandatory items like title tag uniqueness, or suggested items like URLs being no more than 3 segments. Failing a mandatory item will result in a fail where failing a suggested item will result in a warning.

--- a/config/seo-pro.php
+++ b/config/seo-pro.php
@@ -45,6 +45,10 @@ return [
         'excluded_sites' => [],
     ],
 
+    'json_ld' => [
+        'use_glide_for_logo' => true,
+    ],
+
     'reports' => [
         'keep_recent' => 'all',
         'queue_chunk_size' => 1000,

--- a/src/Cascade.php
+++ b/src/Cascade.php
@@ -572,9 +572,7 @@ class Cascade
                 'name' => $jsonLdOrganizationName,
                 '@id' => $this->homeUrl().'#organization',
                 'url' => $this->homeUrl(),
-                'logo' => $jsonLdOrganizationLogo
-                    ? Statamic::tag('glide')->src($jsonLdOrganizationLogo)->square(512)->absolute(true)->fetch()
-                    : null,
+                'logo' => $this->jsonLdOrganizationLogoUrl($jsonLdOrganizationLogo),
             ]), JSON_UNESCAPED_SLASHES));
         }
 
@@ -610,6 +608,19 @@ class Cascade
         }
 
         return $snippets;
+    }
+
+    protected function jsonLdOrganizationLogoUrl($logo)
+    {
+        if (! $logo) {
+            return null;
+        }
+
+        if (config('statamic.seo-pro.json_ld.use_glide_for_logo', true)) {
+            return Statamic::tag('glide')->src($logo)->square(512)->absolute(true)->fetch();
+        }
+
+        return $logo->absoluteUrl();
     }
 
     protected function augmentData($data)

--- a/tests/CascadeTest.php
+++ b/tests/CascadeTest.php
@@ -418,7 +418,7 @@ class CascadeTest extends TestCase
     }
 
     #[Test]
-    public function it_generates_json_ld_organization_logo_with_glide_by_default()
+    public function glide_url_is_returned_for_json_ld_organization_logo()
     {
         $siteDefaults = SiteDefaults::in('default')->set([
             'site_name' => 'Cool Writings',
@@ -440,7 +440,7 @@ class CascadeTest extends TestCase
     }
 
     #[Test]
-    public function it_generates_json_ld_organization_logo_as_permalink_when_glide_disabled()
+    public function permalink_is_returned_for_json_ld_organization_logo_when_config_is_false()
     {
         config(['statamic.seo-pro.json_ld.use_glide_for_logo' => false]);
 

--- a/tests/CascadeTest.php
+++ b/tests/CascadeTest.php
@@ -418,6 +418,50 @@ class CascadeTest extends TestCase
     }
 
     #[Test]
+    public function it_generates_json_ld_organization_logo_with_glide_by_default()
+    {
+        $siteDefaults = SiteDefaults::in('default')->set([
+            'site_name' => 'Cool Writings',
+            'json_ld_entity' => 'organization',
+            'json_ld_organization_name' => 'Cool Runnings Ltd',
+            'json_ld_organization_logo' => 'assets::img/stetson.jpg',
+        ]);
+
+        $data = (new Cascade)
+            ->with($siteDefaults->all())
+            ->get();
+
+        $organization = json_decode($data['json_ld'][0], true);
+
+        $this->assertEquals('Organization', $organization['@type']);
+        $this->assertStringContainsString('/img/asset/', $organization['logo']);
+        $this->assertStringContainsString('w=512', $organization['logo']);
+        $this->assertStringContainsString('h=512', $organization['logo']);
+    }
+
+    #[Test]
+    public function it_generates_json_ld_organization_logo_as_permalink_when_glide_disabled()
+    {
+        config(['statamic.seo-pro.json_ld.use_glide_for_logo' => false]);
+
+        $siteDefaults = SiteDefaults::in('default')->set([
+            'site_name' => 'Cool Writings',
+            'json_ld_entity' => 'organization',
+            'json_ld_organization_name' => 'Cool Runnings Ltd',
+            'json_ld_organization_logo' => 'assets::img/stetson.jpg',
+        ]);
+
+        $data = (new Cascade)
+            ->with($siteDefaults->all())
+            ->get();
+
+        $organization = json_decode($data['json_ld'][0], true);
+
+        $this->assertEquals('Organization', $organization['@type']);
+        $this->assertEquals('http://cool-runnings.com/assets/img/stetson.jpg', $organization['logo']);
+    }
+
+    #[Test]
     public function it_generates_json_ld_breadcrumbs()
     {
         $siteDefaults = SiteDefaults::in('default')->set([


### PR DESCRIPTION
The Glide-generated logo URL in the Organization JSON-LD snippet causes a "Signature is not valid" error in headless setups. I believe this happens because the Statamic backend URL differs from the configured site URL, so GlideController::validateSignature() can't correctly extract the request path and the signature check fails.

This adds a `json_ld.use_glide_for_logo` config option (defaults to true for backward compatibility). When set to false, the logo outputs the asset's permalink directly instead of going through Glide. The idea is that in a headless context, the user can just upload a properly sized image and skip Glide entirely.

Please let me know if this feature doesn't properly fit. Here to help out :)