### PR TITLE
Fix error when generating JSON-LD breadcrumbs

### DIFF
--- a/src/Cascade.php
+++ b/src/Cascade.php
@@ -598,7 +598,7 @@ class Cascade
                     return [
                         '@type' => 'ListItem',
                         'position' => $index,
-                        'name' => $crumb->title,
+                        'name' => $crumb->get('title'),
                         'item' => $crumb->absoluteUrl(),
                     ];
                 })->all(),


### PR DESCRIPTION
This pull request fixes an issue where `Cascade::jsonLd()` would throw a "Cannot access protected property" error when generating breadcrumbs.

This was happening because the code accessed `$crumb->title` as a property, relying on the `__get()` magic method. In certain contexts—specifically when Laravel Telescope serializes an `Entry` via `json_encode()`—the magic method interception doesn't apply, causing PHP to attempt direct access to the protected property.

This PR fixes it by using `$crumb->get('title')` instead, which is a direct method call available on both `Entry` and `Page` objects.

Fixes #512