### PR TITLE
Fix sitemap cache invalidation

### DIFF
--- a/src/Http/Controllers/SitemapController.php
+++ b/src/Http/Controllers/SitemapController.php
@@ -16,7 +16,7 @@ class SitemapController extends Controller
         abort_unless(config('statamic.seo-pro.sitemap.enabled'), 404);
 
         $cacheUntil = Carbon::now()->addMinutes(config('statamic.seo-pro.sitemap.expire'));
-        $cacheKey = implode('_', [Sitemap::CACHE_KEY, request()->getHttpHost(), $this->sitemap->sites()->map->handle()->join('')]);
+        $cacheKey = $this->cacheKey();
 
         if (config('statamic.seo-pro.sitemap.pagination.enabled', false)) {
             $content = Cache::remember("{$cacheKey}_index", $cacheUntil, function () {
@@ -44,7 +44,7 @@ class SitemapController extends Controller
         abort_unless(filter_var($page, FILTER_VALIDATE_INT), 404);
 
         $cacheUntil = Carbon::now()->addMinutes(config('statamic.seo-pro.sitemap.expire'));
-        $cacheKey = implode('_', [Sitemap::CACHE_KEY, $page, request()->getHttpHost(), $this->sitemap->sites()->map->handle()->join('')]);
+        $cacheKey = $this->cacheKey($page);
 
         $content = Cache::remember($cacheKey, $cacheUntil, function () use ($page) {
             abort_if(empty($pages = $this->sitemap->paginatedPages($page)), 404);
@@ -56,5 +56,19 @@ class SitemapController extends Controller
         });
 
         return response($content)->header('Content-Type', 'text/xml');
+    }
+
+    protected function cacheKey(string $suffix = ''): string
+    {
+        $key = collect([
+            Sitemap::CACHE_KEY,
+            request()->getHttpHost(),
+            $this->sitemap->sites()->map->handle()->join(''),
+            $suffix,
+        ])->filter()->implode('_');
+
+        Sitemap::trackCacheKey($key);
+
+        return $key;
     }
 }

--- a/src/Sitemap/Sitemap.php
+++ b/src/Sitemap/Sitemap.php
@@ -3,6 +3,7 @@
 namespace Statamic\SeoPro\Sitemap;
 
 use Illuminate\Support\Collection as IlluminateCollection;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Str;
 use Statamic\Contracts\Entries\Entry;
@@ -24,6 +25,24 @@ class Sitemap
     use GetsSectionDefaults, Hookable;
 
     const CACHE_KEY = 'seo-pro.sitemap';
+
+    public static function invalidateCache(): void
+    {
+        foreach (Cache::get(self::CACHE_KEY.'.keys', []) as $key) {
+            Cache::forget($key);
+        }
+
+        Cache::forget(self::CACHE_KEY.'.keys');
+    }
+
+    public static function trackCacheKey(string $key): void
+    {
+        $keys = Cache::get(self::CACHE_KEY.'.keys', []);
+
+        if (! in_array($key, $keys)) {
+            Cache::forever(self::CACHE_KEY.'.keys', [...$keys, $key]);
+        }
+    }
 
     public function pages(): array
     {

--- a/src/Subscriber.php
+++ b/src/Subscriber.php
@@ -2,7 +2,6 @@
 
 namespace Statamic\SeoPro;
 
-use Illuminate\Support\Facades\Cache;
 use Statamic\Events;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Taxonomy;
@@ -20,9 +19,13 @@ class Subscriber
         Events\EntryBlueprintFound::class => 'ensureSeoFields',
         Events\TermBlueprintFound::class => 'ensureSeoFields',
         Events\CollectionSaved::class => 'clearSitemapCache',
+        Events\CollectionDeleted::class => 'clearSitemapCache',
         Events\EntrySaved::class => 'clearSitemapCache',
+        Events\EntryDeleted::class => 'clearSitemapCache',
         Events\TaxonomySaved::class => 'clearSitemapCache',
+        Events\TaxonomyDeleted::class => 'clearSitemapCache',
         Events\TermSaved::class => 'clearSitemapCache',
+        Events\TermDeleted::class => 'clearSitemapCache',
     ];
 
     /**
@@ -54,7 +57,7 @@ class Subscriber
      */
     public function clearSitemapCache()
     {
-        Cache::forget(Sitemap::CACHE_KEY);
+        Sitemap::invalidateCache();
     }
 
     /**

--- a/tests/SitemapTest.php
+++ b/tests/SitemapTest.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection as IlluminateCollection;
+use Illuminate\Support\Facades\Cache;
 use Orchestra\Testbench\Attributes\DefineEnvironment;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -564,6 +565,42 @@ class SitemapTest extends TestCase
                 '</url>',
                 '</urlset>',
             ], escape: false);
+    }
+
+    #[Test]
+    public function it_invalidates_sitemap_cache_when_entry_is_saved()
+    {
+        $this->get('/sitemap.xml')->assertOk();
+
+        $this->assertNotEmpty(Cache::get(Sitemap::CACHE_KEY.'.keys'));
+
+        Entry::findByUri('/about')->entry()->save();
+
+        $this->assertNull(Cache::get(Sitemap::CACHE_KEY.'.keys'));
+    }
+
+    #[Test]
+    public function it_invalidates_sitemap_cache_when_entry_is_deleted()
+    {
+        $this->get('/sitemap.xml')->assertOk();
+
+        $this->assertNotEmpty(Cache::get(Sitemap::CACHE_KEY.'.keys'));
+
+        Entry::findByUri('/about')->entry()->delete();
+
+        $this->assertNull(Cache::get(Sitemap::CACHE_KEY.'.keys'));
+    }
+
+    #[Test]
+    public function it_invalidates_sitemap_cache_when_collection_is_saved()
+    {
+        $this->get('/sitemap.xml')->assertOk();
+
+        $this->assertNotEmpty(Cache::get(Sitemap::CACHE_KEY.'.keys'));
+
+        Collection::find('pages')->save();
+
+        $this->assertNull(Cache::get(Sitemap::CACHE_KEY.'.keys'));
     }
 }
 


### PR DESCRIPTION
This pull request fixes an issue where the sitemap cache wasn't being invalidated properly when entries and terms are updated.

Likely caused by #344 or #399 (depending on if pagination is enabled) where extra _stuff_ was appended to the cache key, but we only ever invalidated the plain cache key.

This PR fixes it by tracking cache keys and clearing them whenever something is saved.

Fixes #509