### PR TITLE
Remember tab in site defaults publish form

### DIFF
--- a/resources/js/pages/site-defaults/Edit.vue
+++ b/resources/js/pages/site-defaults/Edit.vue
@@ -150,6 +150,7 @@ const switchToLocalization = (localization) => {
 			:sync-field-confirmation-text
 			:track-dirty-state="true"
 			as-config
+			remember-tab
 		/>
 
 		<ConfigureModal


### PR DESCRIPTION
This pull request adds the `remember-tab` prop to the Site Defaults publish form, ensuring the current tab is persisted in the URL hash.