### PR TITLE
Fix border of twitter preview in dark mode

### DIFF
--- a/resources/js/components/fieldtypes/PreviewsFieldtype.vue
+++ b/resources/js/components/fieldtypes/PreviewsFieldtype.vue
@@ -194,7 +194,7 @@ const googleUrlComponents = computed(() => {
 		</Field>
 
 		<Field :label="__('seo-pro::messages.x_twitter_preview')">
-			<a v-if="twitterImageUrl" class="block max-w-[663px] max-h-[347px] rounded-2xl border border-[#CFD9DE] relative overflow-hidden" :href="url" target="_blank">
+			<a v-if="twitterImageUrl" class="block max-w-[663px] max-h-[347px] rounded-2xl border border-[#CFD9DE] dark:border-[#2F3336] relative overflow-hidden" :href="url" target="_blank">
 				<img class="size-full" :src="twitterImageUrl" />
 				<div class="absolute bottom-3 left-3 right-3">
 					<div class="bg-[#000000C4] text-white text-[13px] px-2 inline-flex rounded truncate max-w-xl" v-text="twitterTitle" />


### PR DESCRIPTION
This pull request fixes the border of the Twitter Preview in dark mode.

## Before

<img width="686" height="382" alt="CleanShot 2026-03-13 at 12 19 40" src="https://github.com/user-attachments/assets/65dcb396-2492-4ada-bdaa-4bec74273386" />


## After

<img width="686" height="382" alt="CleanShot 2026-03-13 at 12 19 57" src="https://github.com/user-attachments/assets/d70660f7-78f7-47f5-97bb-358f1f3e0d3c" />
