### PR TITLE
Add missing default values to site defaults

### DIFF
--- a/src/SiteDefaults/Blueprint.php
+++ b/src/SiteDefaults/Blueprint.php
@@ -302,6 +302,7 @@ class Blueprint
                                         'field' => [
                                             'type' => 'text',
                                         ],
+                                        'default' => '@seo:title',
                                     ],
                                 ],
                                 [
@@ -315,6 +316,7 @@ class Blueprint
                                         'field' => [
                                             'type' => 'textarea',
                                         ],
+                                        'default' => '@seo:description',
                                     ],
                                 ],
                             ],

--- a/src/SiteDefaults/Blueprint.php
+++ b/src/SiteDefaults/Blueprint.php
@@ -246,6 +246,7 @@ class Blueprint
                                         'field' => [
                                             'type' => 'text',
                                         ],
+                                        'default' => '@seo:title',
                                     ],
                                 ],
                             ],


### PR DESCRIPTION
This pull request adds default values to the OG/Twitter site default fields. I haven't been able to track down why, but it looks like they were removed as part of v7.

Adding them back doesn't seem to cause any issues - at least the tests don't fail 🎉 