### PR TITLE
Refactor SEO field placeholders

### DIFF
--- a/resources/js/components/fieldtypes/PreviewsFieldtype.vue
+++ b/resources/js/components/fieldtypes/PreviewsFieldtype.vue
@@ -19,12 +19,13 @@ const resolveSeoValue = (field) => {
 
 	if (value.source === 'inherit') {
 		let seoField = publishMeta.value.seo.fields.find(f => f.handle === field);
+		let placeholder = props.meta.placeholders.value[field];
 
-		if (seoField.field?.type === 'assets' && seoField.placeholder) {
-			return props.meta.assetContainerUrl + '/' + seoField.placeholder;
+		if (seoField.field?.type === 'assets' && placeholder) {
+			return props.meta.assetContainerUrl + '/' + placeholder;
 		}
 
-		return seoField.placeholder;
+		return placeholder;
 	}
 
 	if (value.source === 'field') {

--- a/resources/js/components/fieldtypes/PreviewsFieldtype.vue
+++ b/resources/js/components/fieldtypes/PreviewsFieldtype.vue
@@ -13,13 +13,14 @@ const { expose } = Fieldtype.use(emit, props);
 defineExpose(expose);
 
 const { values: publishValues, meta: publishMeta, blueprint } = injectPublishContext();
+const placeholders = computed(() => props.meta.placeholders ?? {});
 
 const resolveSeoValue = (field) => {
 	let value = publishValues.value.seo[field];
 
 	if (value.source === 'inherit') {
 		let seoField = publishMeta.value.seo.fields.find(f => f.handle === field);
-		let placeholder = props.meta.placeholders.value[field];
+		let placeholder = placeholders.value[field];
 
 		if (seoField.field?.type === 'assets' && placeholder) {
 			return props.meta.assetContainerUrl + '/' + placeholder;

--- a/resources/js/components/fieldtypes/SourceFieldtype.vue
+++ b/resources/js/components/fieldtypes/SourceFieldtype.vue
@@ -35,8 +35,8 @@ const sourceTypeSelectOptions = computed(() => {
 	return options;
 });
 
-const fieldConfig = computed(() => Object.assign(props.config.field, { placeholder: props.config.placeholder }));
-const placeholder = computed(() => props.config.placeholder);
+const placeholder = computed(() => props.meta.placeholder ?? null);
+const fieldConfig = computed(() => Object.assign(props.config.field, { placeholder: placeholder.value }));
 
 const sourceFieldOptions = computed(() => {
 	if (publishContainerName.value === 'site-defaults') return false;

--- a/src/Cascade.php
+++ b/src/Cascade.php
@@ -107,8 +107,17 @@ class Cascade
         }
 
         $this->data = $this->data->map(function ($item, $key) {
+            // Skip json_ld_schema. It might need to use resolved SEO values as context.
+            if ($key === 'json_ld_schema') {
+                return $item;
+            }
+
             return $this->parse($key, $item);
         });
+
+        if ($this->data->has('json_ld_schema')) {
+            $this->data->put('json_ld_schema', $this->parseJsonLdSchema($this->data->get('json_ld_schema')));
+        }
 
         return $this->data->merge([
             'compiled_title' => $this->compiledTitle(),
@@ -482,6 +491,23 @@ class Cascade
             return (string) Antlers::parse($item, array_merge(
                 app(ViewCascade::class)->toArray(),
                 $this->current ?? [],
+            ));
+        } catch (RuntimeException $e) {
+            return $item;
+        }
+    }
+
+    protected function parseJsonLdSchema($item)
+    {
+        if (! is_string($item) || ! Str::contains($item, '{{')) {
+            return $item;
+        }
+
+        try {
+            return (string) Antlers::parse($item, array_merge(
+                app(ViewCascade::class)->toArray(),
+                $this->current ?? [],
+                ['seo' => $this->data->all()],
             ));
         } catch (RuntimeException $e) {
             return $item;

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -2,16 +2,11 @@
 
 namespace Statamic\SeoPro;
 
-use Statamic\Assets\Asset;
-use Statamic\Facades\Blink;
-use Statamic\Facades\Site;
 use Statamic\SeoPro\Fieldtypes\Rules\ValidJsonLd;
-use Statamic\SeoPro\SiteDefaults\SiteDefaults;
-use Statamic\Statamic;
 
 class Fields
 {
-    use GetsSectionDefaults, HasAssetField;
+    use HasAssetField;
 
     protected $data;
     protected $isContent;
@@ -70,7 +65,6 @@ class Fields
                         'field' => [
                             'display' => __("seo-pro::fieldsets/{$langFile}.title"),
                             'instructions' => __("seo-pro::fieldsets/{$langFile}.title_instruct"),
-                            'placeholder' => $this->getPlaceholder('title'),
                             'type' => 'seo_pro_source',
                             'disableable' => true,
                             'localizable' => true,
@@ -87,7 +81,6 @@ class Fields
                         'field' => [
                             'display' => __("seo-pro::fieldsets/{$langFile}.description"),
                             'instructions' => __("seo-pro::fieldsets/{$langFile}.description_instruct"),
-                            'placeholder' => $this->getPlaceholder('description'),
                             'type' => 'seo_pro_source',
                             'localizable' => true,
                             'field' => [
@@ -103,7 +96,6 @@ class Fields
                         'field' => [
                             'display' => __("seo-pro::fieldsets/{$langFile}.site_name"),
                             'instructions' => __("seo-pro::fieldsets/{$langFile}.site_name_instruct"),
-                            'placeholder' => $this->getPlaceholder('site_name'),
                             'type' => 'seo_pro_source',
                             'from_field' => false,
                             'disableable' => true,
@@ -118,7 +110,6 @@ class Fields
                         'field' => [
                             'display' => __("seo-pro::fieldsets/{$langFile}.site_name_position"),
                             'instructions' => __("seo-pro::fieldsets/{$langFile}.site_name_position_instruct"),
-                            'placeholder' => $this->getPlaceholder('site_name_position'),
                             'type' => 'seo_pro_source',
                             'from_field' => false,
                             'localizable' => true,
@@ -139,7 +130,6 @@ class Fields
                         'field' => [
                             'display' => __("seo-pro::fieldsets/{$langFile}.site_name_separator"),
                             'instructions' => __("seo-pro::fieldsets/{$langFile}.site_name_separator_instruct"),
-                            'placeholder' => $this->getPlaceholder('site_name_separator'),
                             'type' => 'seo_pro_source',
                             'from_field' => false,
                             'localizable' => true,
@@ -155,7 +145,6 @@ class Fields
                         'field' => [
                             'display' => __("seo-pro::fieldsets/{$langFile}.canonical_url"),
                             'instructions' => __("seo-pro::fieldsets/{$langFile}.canonical_url_instruct"),
-                            'placeholder' => $this->isContent ? $this->getPlaceholder('canonical_url') : false,
                             'type' => 'seo_pro_source',
                             'localizable' => true,
                             'field' => $this->isContent ? ['type' => 'text'] : false,
@@ -174,7 +163,6 @@ class Fields
                         'field' => [
                             'display' => __("seo-pro::fieldsets/{$langFile}.json_ld_schema"),
                             'instructions' => __("seo-pro::fieldsets/{$langFile}.json_ld_schema_instruct"),
-                            'placeholder' => $this->getPlaceholder('json_ld_schema'),
                             'type' => 'seo_pro_source',
                             'from_field' => false,
                             'disableable' => true,
@@ -228,7 +216,6 @@ class Fields
                         'field' => [
                             'display' => __("seo-pro::fieldsets/{$langFile}.robots_indexing"),
                             'instructions' => __("seo-pro::fieldsets/{$langFile}.robots_indexing_instruct"),
-                            'placeholder' => $this->getPlaceholder('robots_indexing'),
                             'type' => 'seo_pro_source',
                             'from_field' => false,
                             'disableable' => true,
@@ -250,7 +237,6 @@ class Fields
                         'field' => [
                             'display' => __("seo-pro::fieldsets/{$langFile}.robots_following"),
                             'instructions' => __("seo-pro::fieldsets/{$langFile}.robots_following_instruct"),
-                            'placeholder' => $this->getPlaceholder('robots_following'),
                             'type' => 'seo_pro_source',
                             'from_field' => false,
                             'disableable' => true,
@@ -272,7 +258,6 @@ class Fields
                         'field' => [
                             'display' => __("seo-pro::fieldsets/{$langFile}.robots_noarchive"),
                             'instructions' => __("seo-pro::fieldsets/{$langFile}.robots_noarchive_instruct"),
-                            'placeholder' => $this->getPlaceholder('robots_noarchive'),
                             'type' => 'seo_pro_source',
                             'from_field' => false,
                             'disableable' => true,
@@ -289,7 +274,6 @@ class Fields
                         'field' => [
                             'display' => __("seo-pro::fieldsets/{$langFile}.robots_noimageindex"),
                             'instructions' => __("seo-pro::fieldsets/{$langFile}.robots_noimageindex_instruct"),
-                            'placeholder' => $this->getPlaceholder('robots_noimageindex'),
                             'type' => 'seo_pro_source',
                             'from_field' => false,
                             'disableable' => true,
@@ -306,7 +290,6 @@ class Fields
                         'field' => [
                             'display' => __("seo-pro::fieldsets/{$langFile}.robots_nosnippet"),
                             'instructions' => __("seo-pro::fieldsets/{$langFile}.robots_nosnippet_instruct"),
-                            'placeholder' => $this->getPlaceholder('robots_nosnippet'),
                             'type' => 'seo_pro_source',
                             'from_field' => false,
                             'disableable' => true,
@@ -344,7 +327,6 @@ class Fields
                         'field' => [
                             'display' => __("seo-pro::fieldsets/{$langFile}.image"),
                             'instructions' => __("seo-pro::fieldsets/{$langFile}.image_instruct"),
-                            'placeholder' => $this->getPlaceholder('image'),
                             'type' => 'seo_pro_source',
                             'localizable' => true,
                             'allowed_fieldtypes' => [
@@ -416,7 +398,6 @@ class Fields
                         'field' => [
                             'display' => __("seo-pro::fieldsets/{$langFile}.sitemap"),
                             'instructions' => __("seo-pro::fieldsets/{$langFile}.sitemap_instruct"),
-                            'placeholder' => $this->getPlaceholder('sitemap'),
                             'type' => 'seo_pro_source',
                             'disableable' => true,
                             'field' => false,
@@ -431,7 +412,6 @@ class Fields
                         'field' => [
                             'display' => __("seo-pro::fieldsets/{$langFile}.priority"),
                             'instructions' => __("seo-pro::fieldsets/{$langFile}.priority_instruct"),
-                            'placeholder' => $this->getPlaceholder('priority'),
                             'type' => 'seo_pro_source',
                             'localizable' => true,
                             'field' => [
@@ -446,7 +426,6 @@ class Fields
                         'field' => [
                             'display' => __("seo-pro::fieldsets/{$langFile}.change_frequency"),
                             'instructions' => __("seo-pro::fieldsets/{$langFile}.change_frequency_instruct"),
-                            'placeholder' => $this->getPlaceholder('change_frequency'),
                             'type' => 'seo_pro_source',
                             'localizable' => true,
                             'field' => [
@@ -467,41 +446,5 @@ class Fields
                 ],
             ],
         ];
-    }
-
-    /**
-     * Get inherited value from SEO cascade for use as placeholder.
-     *
-     * @param  string  $handle
-     * @return mixed
-     */
-    protected function getPlaceholder($handle)
-    {
-        if (! Statamic::isCpRoute()) {
-            return null;
-        }
-
-        $cascade = Blink::once('seo-pro::placeholder.cascade', function () {
-            $cascade = (new Cascade)->withSiteDefaults(SiteDefaults::in($this->data?->locale() ?? Site::selected()->handle())->all());
-
-            if ($this->data) {
-                $cascade = $cascade
-                    ->withSectionDefaults($this->getSectionDefaults($this->data))
-                    ->with($this->data->value('seo', []))
-                    ->withCurrent($this->data);
-            }
-
-            return $cascade;
-        });
-
-        $placeholder = $cascade->value($handle);
-
-        if (is_array($placeholder)) {
-            return collect($placeholder)->implode(', ');
-        } elseif ($placeholder instanceof Asset) {
-            return $placeholder->path();
-        }
-
-        return $placeholder;
     }
 }

--- a/src/Fieldtypes/Concerns/ResolvesPlaceholders.php
+++ b/src/Fieldtypes/Concerns/ResolvesPlaceholders.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Statamic\SeoPro\Fieldtypes\Concerns;
+
+use Statamic\Contracts\Entries\Entry;
+use Statamic\Contracts\Taxonomies\Term;
+use Statamic\Facades\Blink;
+use Statamic\SeoPro\Cascade;
+use Statamic\SeoPro\GetsSectionDefaults;
+use Statamic\SeoPro\SiteDefaults\SiteDefaults;
+
+trait ResolvesPlaceholders
+{
+    use GetsSectionDefaults;
+
+    private function getPlaceholders(): array
+    {
+        $parent = $this->field()?->parent();
+
+        if ($parent instanceof Entry || $parent instanceof Term) {
+            return $this->getEntryPlaceholders($parent);
+        }
+
+        if ($this->isOnSectionDefaultsRoute()) {
+            return $this->getSectionDefaultsPlaceholders();
+        }
+
+        return [];
+    }
+
+    private function getEntryPlaceholders(Entry|Term $parent): array
+    {
+        return Blink::once('seo-pro::placeholders::'.$parent->id(), function () use ($parent) {
+            $cascade = (new Cascade)
+                ->withSiteDefaults(SiteDefaults::in($parent->locale())->all())
+                ->withSectionDefaults($this->getSectionDefaults($parent))
+                ->with($parent->value('seo', []))
+                ->withCurrent($parent)
+                ->get();
+
+            return collect($cascade)->map(function ($value) {
+                if ($value instanceof \Statamic\Assets\Asset) {
+                    return $value->path();
+                }
+
+                if ($value instanceof \Illuminate\Support\Collection) {
+                    return $value->join("\n");
+                }
+
+                if (is_array($value)) {
+                    return implode(', ', $value);
+                }
+
+                return $value;
+            })->all();
+        });
+    }
+
+    private function getSectionDefaultsPlaceholders(): array
+    {
+        $siteDefaults = SiteDefaults::in(request()->route('site') ?? 'default');
+
+        return $siteDefaults?->values()->all() ?? [];
+    }
+
+    private function isOnSectionDefaultsRoute(): bool
+    {
+        $routeName = request()->route()?->getName() ?? '';
+
+        return str_contains($routeName, 'seo-pro.section-defaults.');
+    }
+}

--- a/src/Fieldtypes/SeoProFieldtype.php
+++ b/src/Fieldtypes/SeoProFieldtype.php
@@ -84,7 +84,7 @@ class SeoProFieldtype extends Fieldtype
             ->values()
             ->all();
 
-        return new BlueprintFields($fields);
+        return (new BlueprintFields($fields))->setParent($this->field()->parent());
     }
 
     protected function fieldConfig()

--- a/src/Fieldtypes/SeoProPreviews.php
+++ b/src/Fieldtypes/SeoProPreviews.php
@@ -9,9 +9,12 @@ use Statamic\Facades\Antlers;
 use Statamic\Facades\AssetContainer;
 use Statamic\Facades\Site;
 use Statamic\Fields\Fieldtype;
+use Statamic\SeoPro\Fieldtypes\Concerns\ResolvesPlaceholders;
 
 class SeoProPreviews extends Fieldtype
 {
+    use ResolvesPlaceholders;
+
     public $selectable = false;
 
     public function preload()
@@ -24,6 +27,7 @@ class SeoProPreviews extends Fieldtype
                 ? AssetContainer::find(config('statamic.seo-pro.assets.container'))->url()
                 : null,
             'faviconUrl' => $this->faviconUrl(),
+            'placeholders' => $this->getPlaceholders(),
         ];
     }
 

--- a/src/Fieldtypes/SourceFieldtype.php
+++ b/src/Fieldtypes/SourceFieldtype.php
@@ -2,13 +2,17 @@
 
 namespace Statamic\SeoPro\Fieldtypes;
 
+use Illuminate\Support\Arr;
 use Statamic\Fields\Field;
 use Statamic\Fields\Fieldtype;
+use Statamic\SeoPro\Fieldtypes\Concerns\ResolvesPlaceholders;
 use Statamic\SeoPro\Fieldtypes\Rules\SourceFieldRule;
 use Statamic\Support\Str;
 
 class SourceFieldtype extends Fieldtype
 {
+    use ResolvesPlaceholders;
+
     public static $handle = 'seo_pro_source';
 
     public $selectable = false;
@@ -76,10 +80,13 @@ class SourceFieldtype extends Fieldtype
 
     public function preload()
     {
+        $placeholder = Arr::get($this->getPlaceholders(), $this->field->handle());
+
         if (! $sourceField = $this->sourceField()) {
             return [
                 'fieldMeta' => null,
                 'defaultValue' => null,
+                'placeholder' => $placeholder,
             ];
         }
 
@@ -91,6 +98,7 @@ class SourceFieldtype extends Fieldtype
             'fieldMeta' => $sourceField->setValue($value)->preProcess()->meta(),
             'defaultFieldMeta' => $sourceField->setValue(null)->preProcess()->meta(),
             'defaultValue' => $sourceField->setValue(null)->preProcess()->value(),
+            'placeholder' => $placeholder,
         ];
     }
 

--- a/tests/SourceFieldtypeTest.php
+++ b/tests/SourceFieldtypeTest.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Support\Facades\Request;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Blink;
+use Statamic\Facades\Collection;
+use Statamic\Facades\Entry;
+use Statamic\Facades\Taxonomy;
+use Statamic\Facades\Term;
+use Statamic\Fields\Field;
+use Statamic\SeoPro\Fieldtypes\SourceFieldtype;
+
+class SourceFieldtypeTest extends TestCase
+{
+    #[Test]
+    public function resolves_placeholders_for_entry()
+    {
+        Blink::flush();
+
+        $this->setSeoInSiteDefaults([
+            'site_name' => 'Test Site',
+            'site_name_position' => 'after',
+            'site_name_separator' => '|',
+        ]);
+
+        $collection = tap(Collection::make('posts'))->save();
+
+        $entry = tap(Entry::make()
+            ->collection($collection)
+            ->slug('hello-world')
+            ->data(['title' => 'Hello World']))
+            ->save();
+
+        $this->app->instance('request', Request::create('/cp/collections/posts/entries/'.$entry->id()));
+
+        $field = (new SourceFieldtype)->setField(
+            (new Field('site_name', [
+                'type' => 'seo_pro_source',
+                'field' => false,
+            ]))
+                ->setParent($entry)
+                ->setValue(['source' => 'inherit', 'value' => null])
+        );
+
+        $preloaded = $field->preload();
+
+        $this->assertArrayHasKey('placeholder', $preloaded);
+        $this->assertEquals('Test Site', $preloaded['placeholder']);
+    }
+
+    #[Test]
+    public function resolves_placeholders_for_term()
+    {
+        Blink::flush();
+
+        $this->setSeoInSiteDefaults([
+            'site_name' => 'Test Site',
+        ]);
+
+        $taxonomy = tap(Taxonomy::make('tags'))->save();
+
+        $term = tap(Term::make()
+            ->taxonomy($taxonomy)
+            ->slug('featured')
+            ->data(['title' => 'Featured']))
+            ->save();
+
+        $this->app->instance('request', Request::create('/cp/taxonomies/tags/terms/'.$term->slug()));
+
+        $field = (new SourceFieldtype)->setField(
+            (new Field('site_name', [
+                'type' => 'seo_pro_source',
+                'field' => false,
+            ]))
+                ->setParent($term)
+                ->setValue(['source' => 'inherit', 'value' => null])
+        );
+
+        $preloaded = $field->preload();
+
+        $this->assertArrayHasKey('placeholder', $preloaded);
+        $this->assertEquals('Test Site', $preloaded['placeholder']);
+    }
+
+    #[Test]
+    public function resolves_placeholders_for_section_defaults()
+    {
+        Blink::flush();
+
+        $this->setSeoInSiteDefaults([
+            'site_name' => 'My Site Name',
+            'title' => '@seo:title',
+        ]);
+
+        // Register a fake section defaults route
+        Route::name('statamic.cp.seo-pro.section-defaults.collections.edit')
+            ->get('/cp/seo-pro/section-defaults/collections/{collection}/edit', fn () => null);
+
+        // Create request matching the route
+        $request = Request::create('/cp/seo-pro/section-defaults/collections/articles/edit');
+        $request->setRouteResolver(fn () => Route::getRoutes()->match($request));
+        $this->app->instance('request', $request);
+
+        $field = (new SourceFieldtype)->setField(
+            (new Field('site_name', [
+                'type' => 'seo_pro_source',
+                'field' => false,
+            ]))
+                ->setValue(['source' => 'inherit', 'value' => null])
+        );
+
+        $preloaded = $field->preload();
+
+        $this->assertArrayHasKey('placeholder', $preloaded);
+        $this->assertEquals('My Site Name', $preloaded['placeholder']);
+    }
+
+    #[Test]
+    public function cant_resolve_placeholders_on_unknown_object()
+    {
+        Blink::flush();
+
+        $this->app->instance('request', Request::create('/about'));
+
+        $field = (new SourceFieldtype)->setField(
+            (new Field('title', [
+                'type' => 'seo_pro_source',
+                'field' => ['type' => 'text'],
+            ]))
+                ->setValue(['source' => 'inherit', 'value' => null])
+        );
+
+        $preloaded = $field->preload();
+
+        $this->assertArrayHasKey('placeholder', $preloaded);
+        $this->assertNull($preloaded['placeholder']);
+    }
+
+    /**
+     * @see https://github.com/statamic/seo-pro/issues/521
+     */
+    #[Test]
+    public function json_ld_schema_referencing_seo_fields_doesnt_cause_infinite_loop_()
+    {
+        Blink::flush();
+
+        $collection = tap(Collection::make('articles'))->save();
+
+        $this->setSeoOnCollection($collection, [
+            'title' => '@seo:title',
+            'json_ld_schema' => '{"@context": "https://schema.org", "@type": "Article", "headline": "{{ seo:title }}"}',
+        ]);
+
+        $entry = tap(Entry::make()
+            ->collection($collection)
+            ->slug('test-article')
+            ->data(['title' => 'My Article Title']))
+            ->save();
+
+        $this->app->instance('request', Request::create('/cp/collections/articles/entries/'.$entry->id()));
+
+        $field = (new SourceFieldtype)->setField(
+            (new Field('title', [
+                'type' => 'seo_pro_source',
+                'field' => ['type' => 'text'],
+            ]))
+                ->setParent($entry)
+                ->setValue(['source' => 'inherit', 'value' => null])
+        );
+
+        $preloaded = $field->preload(); // Shouldn't cause an infinite loop.
+
+        $this->assertArrayHasKey('placeholder', $preloaded);
+        $this->assertEquals('My Article Title', $preloaded['placeholder']);
+    }
+}


### PR DESCRIPTION
This pull request refactors how SEO field placeholders are resolved, moving the logic from field configs to fieldtype preloading.

Previously, placeholders were resolved in `Fields.php` when generating the SEO fields array. This was problematic because it would build the Cascade and parse all the values too early. If the JSON-LD schema contained Antlers tags like `{{ seo:title }}`, it would try to resolve the `seo` variable, which would trigger another Cascade build, causing an infinite loop.

This PR fixes it by:

- Moving placeholder resolution from `Fields.php` to the `SourceFieldtype::preload()` method, deferring it until after field configs are built
- Introducing a `ResolvesPlaceholders` trait that centralizes the placeholder logic with Blink caching
- Deferring JSON-LD schema parsing in the Cascade until after other SEO values are resolved, allowing JSON-LD templates to reference fields like `{{ seo:title }}`

The Vue components now receive placeholders via `props.meta` rather than through the field config.

Fixes #521
