### PR TITLE
Fix squished Google preview image

### DIFF
--- a/resources/js/components/fieldtypes/PreviewsFieldtype.vue
+++ b/resources/js/components/fieldtypes/PreviewsFieldtype.vue
@@ -187,7 +187,7 @@ const googleUrlComponents = computed(() => {
 				</div>
 				<a v-if="facebookImageUrl" class="block shrink-0 !pl-[20px]" :href="url" target="_blank">
 					<div class="size-[92px]">
-						<img class="rounded-[8px] size-full object-conver" :src="facebookImageUrl">
+						<img class="rounded-[8px] size-full object-cover" :src="facebookImageUrl">
 					</div>
 				</a>
 			</div>


### PR DESCRIPTION
Partially fixes #519.

## Before
<img width="685" height="202" alt="CleanShot 2026-03-30 at 12 53 49" src="https://github.com/user-attachments/assets/4e2839a7-ab12-4715-8d33-f4bffbeecb87" />


## After

<img width="685" height="202" alt="CleanShot 2026-03-30 at 12 54 09" src="https://github.com/user-attachments/assets/56a2291f-a7e0-4b9f-8eb8-3a3ecd11917b" />
