### PR TITLE
Reload preview images when asset is updated

### DIFF
--- a/resources/js/components/fieldtypes/PreviewsFieldtype.vue
+++ b/resources/js/components/fieldtypes/PreviewsFieldtype.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { Fieldtype } from '@statamic/cms';
 import { Field, injectPublishContext } from '@statamic/cms/ui';
-import { computed, ref, watch, getCurrentInstance } from 'vue';
+import { computed, ref, watch, getCurrentInstance, onMounted, onBeforeUnmount } from 'vue';
 import striptags from "striptags";
 
 const instance = getCurrentInstance();
@@ -162,6 +162,15 @@ const googleUrlComponents = computed(() => {
 
 	return [origin, ...pathSegments];
 });
+
+const onAssetSaved = (asset) => {
+	if (image && asset.id === image.value) {
+		Statamic.$callbacks.call('bustAndReloadImageCaches', [twitterImageUrl.value, facebookImageUrl.value]);
+	}
+};
+
+onMounted(() => Statamic.$events.$on('asset.saved', onAssetSaved));
+onBeforeUnmount(() => Statamic.$events.$off('asset.saved', onAssetSaved));
 </script>
 
 <template>


### PR DESCRIPTION
This pull request ensures that preview images are (hard) reloaded after an asset is saved, handling situations where the image has been cropped or had its focal point changed.


https://github.com/user-attachments/assets/f25599ea-81f7-42d3-93dc-5bf00c335e99


Closes #519
Related: https://github.com/statamic/cms/pull/14392