### PR TITLE
Previews field shouldn't be localizable

### DIFF
--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -77,7 +77,7 @@ class Blueprint
                 'type' => 'seo_pro_previews',
                 'listable' => false,
                 'display' => 'SEO Previews',
-                'localizable' => true,
+                'localizable' => false,
                 'hide_display' => true,
                 'unless' => ['seo.enabled' => 'equals false'],
             ],


### PR DESCRIPTION
The field powering SEO Pro's previews feature shouldn't be localizable. We don't want to see the link/unlink button above it because it doesn't make sense for a field that doesn't save anything.

## Before

<img width="713" height="354" alt="CleanShot 2026-03-30 at 17 02 48" src="https://github.com/user-attachments/assets/0b41e993-3f1a-41ac-924a-9117e9af6255" />


## After

<img width="713" height="354" alt="CleanShot 2026-03-30 at 17 02 13" src="https://github.com/user-attachments/assets/8cb7e2af-4711-4d81-baa9-394aca4ec296" />
