### PR TITLE
Fix "Array to string conversion" error when resolving placeholders

### DIFF
--- a/src/Fieldtypes/Concerns/ResolvesPlaceholders.php
+++ b/src/Fieldtypes/Concerns/ResolvesPlaceholders.php
@@ -47,7 +47,7 @@ trait ResolvesPlaceholders
                     return $value->join("\n");
                 }
 
-                if (is_array($value)) {
+                if (is_array($value) && is_string(array_first($value))) {
                     return implode(', ', $value);
                 }
 


### PR DESCRIPTION
This pull request fixes an "Array to string conversion" error when resolving placeholders in a multi-site. 

The `ResolvesPlaceholders` trait loops through the keys returned by the cascade and attempts to format them correctly for the "frontend".

Caused by #523 (which hasn't been released yet)