### PR TITLE
Fix site defaults disappearing when using Antlers values

### DIFF
--- a/src/SiteDefaults/SiteDefaults.php
+++ b/src/SiteDefaults/SiteDefaults.php
@@ -13,7 +13,7 @@ class SiteDefaults
     public static function get(): Collection
     {
         return Blink::once('seo-pro::site-defaults', function () {
-            $data = Addon::get('statamic/seo-pro')->settings()->get('site_defaults', []);
+            $data = Arr::get(Addon::get('statamic/seo-pro')->settings()->raw(), 'site_defaults', []);
 
             return Site::all()->map(function ($site) use ($data) {
                 $values = Arr::get($data, Site::multiEnabled() ? $site->handle() : null);
@@ -56,7 +56,7 @@ class SiteDefaults
 
     public static function save(LocalizedSiteDefaults $localized): bool
     {
-        $data = Addon::get('statamic/seo-pro')->settings()->get('site_defaults', []);
+        $data = Arr::get(Addon::get('statamic/seo-pro')->settings()->raw(), 'site_defaults', []);
 
         if (Site::multiEnabled()) {
             $data[$localized->locale()] = $localized->all();


### PR DESCRIPTION
Currently we `get()` the addon's values which evaluates Antlers and returns an empty value since there is nothing to render. This PR fixes it by getting the `raw()` values instead since we want to actually get the raw Antlers string/value from the site defaults.

Closes https://github.com/statamic/seo-pro/issues/533.