### PR TITLE
Stack title and description on small widths in report summary

### DIFF
--- a/resources/js/pages/reports/Show.vue
+++ b/resources/js/pages/reports/Show.vue
@@ -92,9 +92,13 @@ if (isGenerating.value) {
 							<td class="w-8 text-center text-pretty">
 								<StatusIcon :status="item.status" />
 							</td>
-							<td class="!pl-0">{{ item.description }}</td>
-							<td class="text-right text-pretty">
-								<Description :text="item.comment" />
+							<td class="!pl-0">
+								<div class="flex flex-col sm:flex-row sm:items-baseline sm:justify-between gap-1">
+									<span>{{ item.description }}</span>
+									<span v-if="item.comment" class="text-gray-700 dark:text-dark-175 sm:text-right text-pretty">
+										<Description :text="item.comment" />
+									</span>
+								</div>
 							</td>
 						</tr>
 					</tbody>


### PR DESCRIPTION
This pull request fixes an issue where the title and description columns in the report summary items were displayed side-by-side on small screens, causing them to be cramped and hard to read.

This PR fixes it by merging the description and comment into a single table cell with a flex layout that stacks vertically on small screens and displays horizontally on `sm` breakpoints and above.

## Before

<img width="500" height="724" alt="CleanShot 2026-04-17 at 11 15 50" src="https://github.com/user-attachments/assets/12af868b-5b1a-4ed6-98be-ee9362a31877" />


## After

<img width="500" height="613" alt="CleanShot 2026-04-17 at 11 15 23" src="https://github.com/user-attachments/assets/13ac6c5b-c5f3-49a3-9e16-63eccb5a9cea" />
