### PR TITLE
Fix robots meta ignoring new fields when legacy array exists

### DIFF
--- a/src/Cascade.php
+++ b/src/Cascade.php
@@ -534,20 +534,6 @@ class Cascade
 
     protected function robots()
     {
-        if ($this->data->has('robots')) {
-            $robots = $this->data->get('robots');
-
-            if ($robots instanceof \Statamic\Fields\Value) {
-                $robots = $robots->value();
-            }
-
-            if (is_array($robots) && ! empty($robots) && isset($robots[0]['key'])) {
-                return collect($robots)->pluck('key')->toArray();
-            }
-
-            return is_array($robots) ? $robots : [];
-        }
-
         $robots = [];
 
         if ($indexing = $this->data->get('robots_indexing')) {
@@ -568,6 +554,24 @@ class Cascade
 
         if ($this->data->get('robots_nosnippet')) {
             $robots[] = 'nosnippet';
+        }
+
+        if (! empty($robots)) {
+            return $robots;
+        }
+
+        if ($this->data->has('robots')) {
+            $robots = $this->data->get('robots');
+
+            if ($robots instanceof \Statamic\Fields\Value) {
+                $robots = $robots->value();
+            }
+
+            if (is_array($robots) && ! empty($robots) && isset($robots[0]['key'])) {
+                return collect($robots)->pluck('key')->toArray();
+            }
+
+            return is_array($robots) ? $robots : [];
         }
 
         return $robots;

--- a/tests/MetaTagTest.php
+++ b/tests/MetaTagTest.php
@@ -641,6 +641,28 @@ EOT;
 
     #[Test]
     #[DataProvider('viewScenarioProvider')]
+    public function it_uses_robots_indexing_and_following_over_legacy_robots_array($viewType)
+    {
+        $this->prepareViews($viewType);
+
+        // Site defaults have the legacy robots array (eg. from a v5 migration)
+        $this->setSeoInSiteDefaults([
+            'robots' => ['index', 'follow'],
+        ]);
+
+        // Entry explicitly sets the new robots_indexing/robots_following fields
+        $this->setSeoOnEntry(Entry::findByUri('/about'), [
+            'robots_indexing' => 'noindex',
+            'robots_following' => 'nofollow',
+        ]);
+
+        $response = $this->get('/about');
+        $response->assertSee("<h1>{$viewType}</h1>", false);
+        $response->assertSee('<meta name="robots" content="noindex, nofollow" />', false);
+    }
+
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_generates_custom_humans_url($viewType)
     {
         Config::set('statamic.seo-pro.humans.url', 'aliens.md');


### PR DESCRIPTION
This pull request fixes an issue where the `robots_indexing` and `robots_following` fields were ignored when the legacy `robots` array was present in the cascade data.

This was happening because `Cascade::robots()` checked for the legacy `robots` array first and returned early if it existed. In practice, this meant that if site defaults still had the old `robots: [index, follow]` format (e.g. from a v5 migration that was never re-saved), any explicit `robots_indexing` or `robots_following` values set on an entry or localized site were silently ignored.

This PR fixes it by reversing the priority in `Cascade::robots()` — the newer `robots_indexing`/`robots_following` fields are now checked first. The legacy `robots` array is only used as a fallback when none of the new fields are set.

Fixes #535
Caused by #405
Caused by #441