### PR TITLE
Support custom JSON-LD schema in site defaults

### DIFF
--- a/lang/en/fieldsets/defaults.php
+++ b/lang/en/fieldsets/defaults.php
@@ -36,6 +36,11 @@ return [
     'json_ld_person_name' => 'Person Name',
     'json_ld_person_name_instruct' => 'The full name of the person this site represents.',
 
+    'json_ld_custom_section' => 'Custom Schema',
+    'json_ld_custom_section_instruct' => 'Add custom JSON-LD schema that will be included on every page across your site.',
+    'json_ld_schema' => 'Schema',
+    'json_ld_schema_instruct' => 'Paste your custom schema objects here (`LocalBusiness`, `SoftwareApplication`, etc). You can use Antlers to output data from the item. Will be wrapped in the appropriate script tag.',
+
     'json_ld_breadcrumbs_section' => 'Breadcrumbs',
     'json_ld_breadcrumbs' => 'Breadcrumbs',
     'json_ld_breadcrumbs_instruct' => 'Enable breadcrumb structured data to show this page\'s location in your site hierarchy in search results. [Learn more](https://developers.google.com/search/docs/appearance/structured-data/breadcrumb)',

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -166,7 +166,7 @@ class Fields
                             'type' => 'seo_pro_source',
                             'from_field' => false,
                             'disableable' => true,
-                            'inherit' => $this->isContent,
+                            'inherit' => true,
                             'localizable' => true,
                             'full_width_setting' => true,
                             'field' => [

--- a/src/SiteDefaults/Blueprint.php
+++ b/src/SiteDefaults/Blueprint.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\SeoPro\SiteDefaults;
 
+use Statamic\SeoPro\Fieldtypes\Rules\ValidJsonLd;
 use Statamic\SeoPro\HasAssetField;
 
 class Blueprint
@@ -143,6 +144,29 @@ class Blueprint
                                         'type' => 'text',
                                         'localizable' => true,
                                         'if' => ['json_ld_entity' => 'equals person'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [
+                            'display' => __('seo-pro::fieldsets/defaults.json_ld_custom_section'),
+                            'instructions' => __('seo-pro::fieldsets/defaults.json_ld_custom_section_instruct'),
+                            'fields' => [
+                                [
+                                    'handle' => 'json_ld_schema',
+                                    'field' => [
+                                        'display' => __('seo-pro::fieldsets/defaults.json_ld_schema'),
+                                        'instructions' => __('seo-pro::fieldsets/defaults.json_ld_schema_instruct'),
+                                        'type' => 'code',
+                                        'mode' => 'javascript',
+                                        'mode_selectable' => false,
+                                        'show_mode_label' => false,
+                                        'localizable' => true,
+                                        'full_width_setting' => true,
+                                        'fullscreen' => false,
+                                        'validate' => [
+                                            new ValidJsonLd,
+                                        ],
                                     ],
                                 ],
                             ],

--- a/tests/CascadeTest.php
+++ b/tests/CascadeTest.php
@@ -418,6 +418,29 @@ class CascadeTest extends TestCase
     }
 
     #[Test]
+    public function it_generates_json_ld_data_with_custom_schema_from_site_defaults()
+    {
+        $siteDefaults = SiteDefaults::in('default')->set([
+            'site_name' => 'Cool Writings',
+            'json_ld_entity' => 'organization',
+            'json_ld_organization_name' => 'Cool Runnings Ltd',
+            'json_ld_schema' => '{"@context":"https://schema.org","@type":"LocalBusiness","name":"Cool Runnings Ltd"}',
+        ]);
+
+        $data = (new Cascade)
+            ->with($siteDefaults->all())
+            ->with([
+                'title' => 'Home',
+            ])
+            ->get();
+
+        $this->assertEquals([
+            '{"@context":"https://schema.org","@type":"Organization","name":"Cool Runnings Ltd","@id":"http://cool-runnings.com#organization","url":"http://cool-runnings.com"}',
+            '{"@context":"https://schema.org","@type":"LocalBusiness","name":"Cool Runnings Ltd"}',
+        ], $data['json_ld']->all());
+    }
+
+    #[Test]
     public function glide_url_is_returned_for_json_ld_organization_logo()
     {
         $siteDefaults = SiteDefaults::in('default')->set([


### PR DESCRIPTION
This pull request adds support for custom JSON-LD schema in site defaults, alongside the existing Organization/Person entity schema.

Previously, custom JSON-LD schemas could only be configured in section defaults and on individual entries/terms. The custom schema set in site defaults will be included on every page and can be overridden at the section or entry level, just like other SEO fields.

<img width="1040" height="988" alt="CleanShot 2026-04-21 at 11 50 12" src="https://github.com/user-attachments/assets/9f357502-bb32-47bf-b6d9-218a423b405c" />

<p></p>

Closes #536