### PR TITLE
Fix Antlers parsing for JSON-LD (site defaults)

### DIFF
--- a/src/Cascade.php
+++ b/src/Cascade.php
@@ -499,6 +499,10 @@ class Cascade
 
     protected function parseJsonLdSchema($item)
     {
+        if ($item instanceof Value) {
+            $item = $item->raw();
+        }
+
         if (! is_string($item) || ! Str::contains($item, '{{')) {
             return $item;
         }

--- a/tests/CascadeTest.php
+++ b/tests/CascadeTest.php
@@ -451,7 +451,7 @@ class CascadeTest extends TestCase
             ->with($siteDefaults->all())
             ->get();
 
-        $this->assertEquals('{"@context":"https://schema.org","@type":"WebPage","name":"Home"}', $data['json_ld']->all());
+        $this->assertEquals('{"@context":"https://schema.org","@type":"WebPage","name":"Home"}', $data['json_ld']->last());
     }
 
     #[Test]

--- a/tests/CascadeTest.php
+++ b/tests/CascadeTest.php
@@ -441,6 +441,20 @@ class CascadeTest extends TestCase
     }
 
     #[Test]
+    public function it_parses_antlers_in_json_ld_schema_values()
+    {
+        $siteDefaults = SiteDefaults::in('default')->set([
+            'json_ld_schema' => new \Statamic\Fields\Value('{"@context":"https://schema.org","@type":"WebPage","name":"{{ title }}"}'),
+        ]);
+
+        $data = (new Cascade)
+            ->with($siteDefaults->all())
+            ->get();
+
+        $this->assertEquals('{"@context":"https://schema.org","@type":"WebPage","name":"Home"}', $data['json_ld']->all());
+    }
+
+    #[Test]
     public function glide_url_is_returned_for_json_ld_organization_logo()
     {
         $siteDefaults = SiteDefaults::in('default')->set([


### PR DESCRIPTION
This fixes custom JSON-LD schema using Antlers and not being properly rendered/evaluated but the literal string being in the output, like `"name": "{{ title }}"` instead of `Home` when the `title` is set to `Home`.

The `Antlers::parse()` was skipped because of an early `is_string()` check when the input was a `Value` object.

Closes https://github.com/statamic/seo-pro/issues/543.