### PR TITLE
Widget header tweaks

### DIFF
--- a/resources/js/components/widgets/SeoProWidget.vue
+++ b/resources/js/components/widgets/SeoProWidget.vue
@@ -10,7 +10,7 @@ defineProps({
 </script>
 
 <template>
-	<Widget :title="__('SEO Pro')" :icon>
+	<Widget :title="__('SEO Pro')" :href="reportsUrl" :icon>
 		<template #actions>
 			<Button :href="reportsUrl" size="sm" :text="__('seo-pro::messages.reports')" />
 		</template>

--- a/resources/js/components/widgets/SeoProWidget.vue
+++ b/resources/js/components/widgets/SeoProWidget.vue
@@ -12,7 +12,7 @@ defineProps({
 <template>
 	<Widget :title="__('SEO Pro')" :href="reportsUrl" :icon>
 		<template #actions>
-			<Button :href="reportsUrl" size="sm" :text="__('seo-pro::messages.reports')" />
+			<Button :href="reportsUrl" size="sm" :text="__('seo-pro::messages.view_reports')" />
 		</template>
 
 		<div v-if="report" class="flex flex-col items-center justify-center gap-4" style="min-height: 159px">


### PR DESCRIPTION
This pull request tweaks two things with the SEO Pro report widget:

- The header is now a link, like the widgets in Core.
- The button label is now "View reports", rather than just "View". Makes it a _little_ more consistent w/ the form widget which uses "View all"