### PR TITLE
Fix redirect description persistence

### DIFF
--- a/src/Http/Controllers/CP/RedirectController.php
+++ b/src/Http/Controllers/CP/RedirectController.php
@@ -3,6 +3,7 @@
 namespace Statamic\SeoPro\Http\Controllers\CP;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Inertia\Inertia;
 use Statamic\CP\Column;
 use Statamic\CP\PublishForm;
@@ -134,7 +135,8 @@ class RedirectController extends CpController
             ->source($values['source'])
             ->destination($values['destination'])
             ->responseCode($values['response_code'])
-            ->enabled($values['enabled']);
+            ->enabled($values['enabled'])
+            ->data($this->redirectData($values));
 
         $redirect->save();
 
@@ -181,9 +183,22 @@ class RedirectController extends CpController
             ->source($values['source'])
             ->destination($values['destination'])
             ->responseCode($values['response_code'])
-            ->enabled($values['enabled']);
+            ->enabled($values['enabled'])
+            ->data($this->redirectData($values));
 
         $redirect->save();
+    }
+
+    private function redirectData(array $values): array
+    {
+        return Arr::except($values, [
+            'source',
+            'destination',
+            'response_code',
+            'enabled',
+            'hits',
+            'last_hit_at',
+        ]);
     }
 
     public function destroy(Request $request, Redirect $redirect)

--- a/src/Http/Controllers/CP/RedirectController.php
+++ b/src/Http/Controllers/CP/RedirectController.php
@@ -132,11 +132,11 @@ class RedirectController extends CpController
 
         $redirect = Facades\Redirect::make()
             ->site($siteHandle)
-            ->source($values['source'])
-            ->destination($values['destination'])
-            ->responseCode($values['response_code'])
-            ->enabled($values['enabled'])
-            ->data($this->redirectData($values));
+            ->source(Arr::pull($values, 'source'))
+            ->destination(Arr::pull($values, 'destination'))
+            ->responseCode(Arr::pull($values, 'response_code'))
+            ->enabled(Arr::pull($values, 'enabled'))
+            ->data($values);
 
         $redirect->save();
 
@@ -180,25 +180,13 @@ class RedirectController extends CpController
         $values = PublishForm::make(Facades\Redirect::blueprint())->submit($request->all());
 
         $redirect
-            ->source($values['source'])
-            ->destination($values['destination'])
-            ->responseCode($values['response_code'])
-            ->enabled($values['enabled'])
-            ->data($this->redirectData($values));
+            ->source(Arr::pull($values, 'source'))
+            ->destination(Arr::pull($values, 'destination'))
+            ->responseCode(Arr::pull($values, 'response_code'))
+            ->enabled(Arr::pull($values, 'enabled'))
+            ->data($values);
 
         $redirect->save();
-    }
-
-    private function redirectData(array $values): array
-    {
-        return Arr::except($values, [
-            'source',
-            'destination',
-            'response_code',
-            'enabled',
-            'hits',
-            'last_hit_at',
-        ]);
     }
 
     public function destroy(Request $request, Redirect $redirect)

--- a/tests/Redirects/CreateRedirectTest.php
+++ b/tests/Redirects/CreateRedirectTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Role;
 use Statamic\Facades\User;
+use Statamic\SeoPro\Facades;
 use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
 use Tests\TestCase;
 
@@ -23,6 +24,25 @@ class CreateRedirectTest extends TestCase
             ->get(cp_route('seo-pro.redirects.create'))
             ->assertOk()
             ->assertSee('Create Redirect');
+    }
+
+    #[Test]
+    public function it_saves_redirect_description_when_creating()
+    {
+        $this
+            ->actingAs(User::make()->makeSuper()->save())
+            ->post(cp_route('seo-pro.redirects.store'), [
+                'source' => '/old-url',
+                'destination' => '/new-url',
+                'response_code' => 301,
+                'enabled' => true,
+                'description' => 'Keep this redirect for the old campaign.',
+            ])
+            ->assertOk();
+
+        $redirect = Facades\Redirect::query()->where('source', '/old-url')->first();
+
+        $this->assertEquals('Keep this redirect for the old campaign.', $redirect->get('description'));
     }
 
     #[Test]

--- a/tests/Redirects/CreateRedirectTest.php
+++ b/tests/Redirects/CreateRedirectTest.php
@@ -6,7 +6,6 @@ use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Role;
 use Statamic\Facades\User;
-use Statamic\SeoPro\Facades;
 use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
 use Tests\TestCase;
 
@@ -24,25 +23,6 @@ class CreateRedirectTest extends TestCase
             ->get(cp_route('seo-pro.redirects.create'))
             ->assertOk()
             ->assertSee('Create Redirect');
-    }
-
-    #[Test]
-    public function it_saves_redirect_description_when_creating()
-    {
-        $this
-            ->actingAs(User::make()->makeSuper()->save())
-            ->post(cp_route('seo-pro.redirects.store'), [
-                'source' => '/old-url',
-                'destination' => '/new-url',
-                'response_code' => 301,
-                'enabled' => true,
-                'description' => 'Keep this redirect for the old campaign.',
-            ])
-            ->assertOk();
-
-        $redirect = Facades\Redirect::query()->where('source', '/old-url')->first();
-
-        $this->assertEquals('Keep this redirect for the old campaign.', $redirect->get('description'));
     }
 
     #[Test]

--- a/tests/Redirects/StoreRedirectTest.php
+++ b/tests/Redirects/StoreRedirectTest.php
@@ -170,4 +170,23 @@ class StoreRedirectTest extends TestCase
             ])
             ->assertSessionHasErrors('source');
     }
+
+    #[Test]
+    public function can_store_redirect_with_description()
+    {
+        $this
+            ->actingAs(User::make()->makeSuper()->save())
+            ->post(cp_route('seo-pro.redirects.store'), [
+                'source' => '/old-url',
+                'destination' => '/new-url',
+                'response_code' => 301,
+                'enabled' => true,
+                'description' => 'Keep this redirect for the old campaign.',
+            ])
+            ->assertOk();
+
+        $redirect = Facades\Redirect::query()->where('source', '/old-url')->first();
+
+        $this->assertEquals('Keep this redirect for the old campaign.', $redirect->get('description'));
+    }
 }

--- a/tests/Redirects/UpdateRedirectTest.php
+++ b/tests/Redirects/UpdateRedirectTest.php
@@ -43,34 +43,6 @@ class UpdateRedirectTest extends TestCase
     }
 
     #[Test]
-    public function it_saves_redirect_description_when_updating()
-    {
-        Facades\Redirect::make()
-            ->id('abc')
-            ->source('/old-url')
-            ->destination('/new-url')
-            ->responseCode(302)
-            ->enabled(true)
-            ->data(['description' => 'Original description.'])
-            ->save();
-
-        $this
-            ->actingAs(User::make()->makeSuper()->save())
-            ->patch(cp_route('seo-pro.redirects.update', 'abc'), [
-                'source' => '/old-url',
-                'destination' => '/new-url',
-                'response_code' => 302,
-                'enabled' => true,
-                'description' => 'Updated description.',
-            ])
-            ->assertOk();
-
-        $redirect = Facades\Redirect::find('abc');
-
-        $this->assertEquals('Updated description.', $redirect->get('description'));
-    }
-
-    #[Test]
     public function cant_update_redirect_without_permission()
     {
         Facades\Redirect::make()
@@ -241,5 +213,33 @@ class UpdateRedirectTest extends TestCase
 
         $this->assertEquals('/old-url', $redirect->source());
         $this->assertEquals('/updated-new-url', $redirect->destination());
+    }
+
+    #[Test]
+    public function can_update_redirect_with_description()
+    {
+        Facades\Redirect::make()
+            ->id('abc')
+            ->source('/old-url')
+            ->destination('/new-url')
+            ->responseCode(302)
+            ->enabled(true)
+            ->data(['description' => 'Original description.'])
+            ->save();
+
+        $this
+            ->actingAs(User::make()->makeSuper()->save())
+            ->patch(cp_route('seo-pro.redirects.update', 'abc'), [
+                'source' => '/old-url',
+                'destination' => '/new-url',
+                'response_code' => 302,
+                'enabled' => true,
+                'description' => 'Updated description.',
+            ])
+            ->assertOk();
+
+        $redirect = Facades\Redirect::find('abc');
+
+        $this->assertEquals('Updated description.', $redirect->get('description'));
     }
 }

--- a/tests/Redirects/UpdateRedirectTest.php
+++ b/tests/Redirects/UpdateRedirectTest.php
@@ -43,6 +43,34 @@ class UpdateRedirectTest extends TestCase
     }
 
     #[Test]
+    public function it_saves_redirect_description_when_updating()
+    {
+        Facades\Redirect::make()
+            ->id('abc')
+            ->source('/old-url')
+            ->destination('/new-url')
+            ->responseCode(302)
+            ->enabled(true)
+            ->data(['description' => 'Original description.'])
+            ->save();
+
+        $this
+            ->actingAs(User::make()->makeSuper()->save())
+            ->patch(cp_route('seo-pro.redirects.update', 'abc'), [
+                'source' => '/old-url',
+                'destination' => '/new-url',
+                'response_code' => 302,
+                'enabled' => true,
+                'description' => 'Updated description.',
+            ])
+            ->assertOk();
+
+        $redirect = Facades\Redirect::find('abc');
+
+        $this->assertEquals('Updated description.', $redirect->get('description'));
+    }
+
+    #[Test]
     public function cant_update_redirect_without_permission()
     {
         Facades\Redirect::make()


### PR DESCRIPTION
## Summary

This fixes a bug in the new redirects feature where the **Description** field was shown in the publish form but discarded when creating or updating a redirect.

The controller was only copying the core redirect attributes (`source`, `destination`, `response_code`, and `enabled`) onto the redirect model. Any additional blueprint fields, including `description`, never made it into the redirect's data payload.

## Changes

- Preserve redirect blueprint data on create and update.
- Exclude system/core redirect fields from the custom data payload.
- Add regression tests for saving the `description` field when creating and updating redirects.

## Testing

- `./vendor/bin/pint --dirty`
- `./vendor/bin/phpunit tests/Redirects/CreateRedirectTest.php tests/Redirects/UpdateRedirectTest.php`
