### PR TITLE
Fix test failure from `CascadeTest`

### DIFF
--- a/tests/CascadeTest.php
+++ b/tests/CascadeTest.php
@@ -214,9 +214,7 @@ class CascadeTest extends TestCase
     #[Test]
     public function it_generates_seo_cascade_without_exception_when_no_home_entry_exists()
     {
-        Entry::findByUri('/')->delete();
-
-        Collection::findByHandle('pages')->structure()->in('default')->tree([])->save();
+        Collection::findByHandle('pages')->queryEntries()->get()->each->delete();
 
         $data = (new Cascade)
             ->withSiteDefaults(SiteDefaults::in('default')->all())

--- a/tests/CascadeTest.php
+++ b/tests/CascadeTest.php
@@ -6,6 +6,7 @@ use Illuminate\Pagination\LengthAwarePaginator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Blink;
+use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
@@ -214,6 +215,8 @@ class CascadeTest extends TestCase
     public function it_generates_seo_cascade_without_exception_when_no_home_entry_exists()
     {
         Entry::findByUri('/')->delete();
+
+        Collection::findByHandle('pages')->structure()->in('default')->tree([])->save();
 
         $data = (new Cascade)
             ->withSiteDefaults(SiteDefaults::in('default')->all())


### PR DESCRIPTION
This pull request fixes an issue where the `it_generates_seo_cascade_without_exception_when_no_home_entry_exists` test was failing when running against `statamic/cms` v6.15+.

This was happening because statamic/cms v6.15 fixed URI recalculation for structured collections (statamic/cms#14547, statamic/cms#14564). Previously, deleting the root entry left the URI cache stale, so `Entry::findByUri('/')` returned `null`. Now, URIs are properly recalculated after deletion, causing the next entry in the tree to inherit the `/` URI.

This PR fixes it by also deleting all entries in the collection so nothing can take over as root.