### PR TITLE
Ability to import & export redirects

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -167,6 +167,16 @@ Head to `Tools > SEO Pro > Redirects` to create and manage redirects. Each redir
 
 ![Redirects listing](https://raw.githubusercontent.com/statamic/seo-pro/refs/heads/7.x/docs-redirects.png)
 
+#### Importing & Exporting
+
+You can import and export redirects as CSV files. Click the "Import/Export" dropdown on the Redirects listing page to access these options.
+
+**Exporting** will download a CSV file containing all redirects for your authorized sites, with the following columns: `source`, `destination`, `response_code`, `enabled`, and `description`.
+
+**Importing** accepts a CSV file with a header row. The `source` and `destination` columns are required. The `response_code`, `enabled`, and `description` columns are optional — if omitted, new redirects will use the default response code and be enabled by default.
+
+If a redirect already exists with the same source URL (on the selected site), it will be updated rather than duplicated. When updating, only the columns present in the CSV will be changed — omitted columns will retain their existing values.
+
 #### Wildcards
 
 You can use wildcards in your source URLs. Each `*` captures a segment, and you can reference them in the destination with `$1`, `$2`, etc:

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
     },
     "require": {
         "statamic/cms": "^6.10",
-        "pixelfear/composer-dist-plugin": "^0.1.6"
+        "pixelfear/composer-dist-plugin": "^0.1.6",
+        "spatie/simple-excel": "^3.9"
     },
     "require-dev": {
         "orchestra/testbench": "^10.0 || ^11.0",

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -92,6 +92,13 @@ return [
     'hits' => 'Hits',
     'last_hit_at' => 'Last Hit At',
     'visit_url' => 'Visit URL',
+    'export' => 'Export',
+    'import' => 'Import',
+    'import_export' => 'Import/Export',
+    'import_redirects' => 'Import Redirects',
+    'import_redirects_instructions' => 'Please upload a CSV file containing the redirects you want to import. The CSV file should have a header row, with the following columns:',
+    'import_redirects_instructions_2' => 'Unless specified, new redirects will be enabled by default. If a redirect already exists with the same source URL, it will be updated.',
+    'redirects_imported' => ':created redirect(s) created, :updated redirect(s) updated.',
 
     'rules' => [
         'pass' => 'Pass',

--- a/resources/js/components/redirects/ImportRedirectsModal.vue
+++ b/resources/js/components/redirects/ImportRedirectsModal.vue
@@ -1,0 +1,113 @@
+<script setup>
+import { Modal, Description, ErrorMessage, Button, PublishContainer, PublishFieldsProvider, PublishFields } from '@statamic/cms/ui';
+import { ref, getCurrentInstance } from 'vue';
+
+const instance = getCurrentInstance();
+const { $axios } = instance.appContext.config.globalProperties;
+
+const emit = defineEmits(['closed', 'imported']);
+
+const open = ref(true);
+const busy = ref(false);
+const error = ref(null);
+const values = ref({ file: [] });
+const meta = ref({
+	file: {
+		uploadUrl: cp_url('fieldtypes/files/upload'),
+	},
+});
+
+const fields = [
+	{
+		handle: 'file',
+		type: 'files',
+		display: __('CSV File'),
+		max_files: 1,
+		allowed_extensions: ['csv'],
+	},
+];
+
+const submit = () => {
+	if (!values.value.file.length) return;
+
+	busy.value = true;
+	error.value = null;
+
+	$axios.post(cp_url('seo-pro/redirects/import'), values.value)
+		.then((response) => {
+			const { created, updated } = response.data;
+
+			Statamic.$toast.success(__('seo-pro::messages.redirects_imported', { created, updated }));
+			emit('imported');
+			close();
+		})
+		.catch((e) => {
+			if (e.response?.status === 422) {
+				error.value = e.response.data.message || e.response.data.errors?.file?.[0];
+			} else {
+				error.value = __('Something went wrong');
+			}
+		})
+		.finally(() => {
+			busy.value = false;
+		});
+};
+
+const close = () => {
+	open.value = false;
+	setTimeout(() => emit('closed'), 200);
+};
+</script>
+
+<template>
+	<Modal
+		:title="__('seo-pro::messages.import_redirects')"
+		:open
+		:dismissable="!busy"
+		@dismissed="close"
+		@update:model-value="close"
+	>
+		<Description class="mb-6">
+			<p>{{ __('seo-pro::messages.import_redirects_instructions') }}</p>
+			<ul class="list-disc list-inside mt-2">
+				<li>{{ __('seo-pro::messages.source') }} ({{ __('required') }})</li>
+				<li>{{ __('seo-pro::messages.destination') }} ({{ __('required') }})</li>
+				<li>{{ __('seo-pro::messages.response_code') }}</li>
+				<li>{{ __('seo-pro::messages.enabled') }}</li>
+				<li>{{ __('seo-pro::messages.description') }}</li>
+			</ul>
+			<p class="mt-2">{{ __('seo-pro::messages.import_redirects_instructions_2') }}</p>
+		</Description>
+
+		<PublishContainer
+			:blueprint="fields"
+			:meta
+			:track-dirty-state="false"
+			v-model="values"
+		>
+			<PublishFieldsProvider :fields>
+				<PublishFields />
+			</PublishFieldsProvider>
+		</PublishContainer>
+
+		<ErrorMessage v-if="error" :text="error" />
+
+		<template #footer>
+			<div class="flex items-center justify-end space-x-3 pt-3 pb-1">
+				<Button
+					variant="ghost"
+					:disabled="busy"
+					:text="__('Cancel')"
+					@click="close"
+				/>
+				<Button
+					type="submit"
+					variant="primary"
+					:disabled="busy || !values.file.length"
+					:text="__('seo-pro::messages.import')"
+					@click="submit"
+				/>
+			</div>
+		</template>
+	</Modal>
+</template>

--- a/resources/js/pages/redirects/Index.vue
+++ b/resources/js/pages/redirects/Index.vue
@@ -1,8 +1,9 @@
 <script setup>
 import { Head, Link } from '@statamic/cms/inertia';
-import { Header, Button, Listing, DropdownItem, DocsCallout } from '@statamic/cms/ui';
+import { Header, Button, Listing, DropdownItem, DocsCallout, Dropdown, DropdownMenu } from '@statamic/cms/ui';
 import StatusIndicator from "../../components/redirects/StatusIndicator.vue";
-import { ref } from 'vue';
+import ImportRedirectsModal from "../../components/redirects/ImportRedirectsModal.vue";
+import { ref, useTemplateRef } from 'vue';
 
 defineProps({
 	blueprint: Object,
@@ -15,6 +16,8 @@ defineProps({
 const items = ref(null);
 const page = ref(null);
 const perPage = ref(null);
+const showImportModal = ref(false);
+const listing = useTemplateRef('listing');
 
 function requestComplete({ items: newItems, parameters }) {
 	items.value = newItems;
@@ -27,6 +30,15 @@ function requestComplete({ items: newItems, parameters }) {
 	<Head :title="__('seo-pro::messages.redirects')" />
 
 	<Header :title="__('seo-pro::messages.redirects')" icon="moved">
+		<Dropdown>
+			<template #trigger>
+				<Button :text="__('seo-pro::messages.import_export')" />
+			</template>
+			<DropdownMenu>
+				<DropdownItem :text="__('seo-pro::messages.export')" icon="download" :href="cp_url('seo-pro/redirects/export')" target="_blank" />
+				<DropdownItem :text="__('seo-pro::messages.import')" icon="upload" @click="showImportModal = true" />
+			</DropdownMenu>
+		</Dropdown>
 		<Button v-if="canCreate" :href="createUrl" :text="__('seo-pro::messages.create_redirect')" variant="primary" />
 	</Header>
 
@@ -56,7 +68,7 @@ function requestComplete({ items: newItems, parameters }) {
 				v-if="redirect.deletable"
 				:ref="`deleter_${redirect.id}`"
 				:resource="redirect"
-				@deleted="$refs.listing.refresh()"
+				@deleted="listing.refresh()"
 			/>
 		</template>
 		<template #cell-status="{ row: redirect }">
@@ -75,4 +87,10 @@ function requestComplete({ items: newItems, parameters }) {
 	</Listing>
 
 	<DocsCallout :topic="__('seo-pro::messages.redirects')" url="https://statamic.com/addons/statamic/seo-pro/docs" />
+
+	<ImportRedirectsModal
+		v-if="showImportModal"
+		@closed="showImportModal = false"
+		@imported="listing.refresh()"
+	/>
 </template>

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -24,6 +24,9 @@ Route::prefix('seo-pro')->name('seo-pro.')->group(function () {
     Route::patch('section-defaults/taxonomies/{seo_pro_taxonomy}', [Controllers\CP\TaxonomyDefaultsController::class, 'update'])->name('section-defaults.taxonomies.update');
 
     Route::resource('errors', Controllers\CP\ErrorController::class)->only('index');
+
+    Route::get('redirects/export', Controllers\CP\Redirects\ExportRedirectsController::class)->name('redirects.export');
+    Route::post('redirects/import', Controllers\CP\Redirects\ImportRedirectsController::class)->name('redirects.import');
     Route::resource('redirects', Controllers\CP\Redirects\RedirectController::class)->except('show');
 
     Route::post('preview', Controllers\CP\PreviewController::class)->name('preview');

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -24,7 +24,7 @@ Route::prefix('seo-pro')->name('seo-pro.')->group(function () {
     Route::patch('section-defaults/taxonomies/{seo_pro_taxonomy}', [Controllers\CP\TaxonomyDefaultsController::class, 'update'])->name('section-defaults.taxonomies.update');
 
     Route::resource('errors', Controllers\CP\ErrorController::class)->only('index');
-    Route::resource('redirects', Controllers\CP\RedirectController::class)->except('show');
+    Route::resource('redirects', Controllers\CP\Redirects\RedirectController::class)->except('show');
 
     Route::post('preview', Controllers\CP\PreviewController::class)->name('preview');
 });

--- a/src/Http/Controllers/CP/Redirects/ExportRedirectsController.php
+++ b/src/Http/Controllers/CP/Redirects/ExportRedirectsController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Statamic\SeoPro\Http\Controllers\CP\Redirects;
+
+use Spatie\SimpleExcel\SimpleExcelWriter;
+use Statamic\Facades\Site;
+use Statamic\Http\Controllers\CP\CpController;
+use Statamic\SeoPro\Facades;
+use Statamic\SeoPro\Redirects\Redirect;
+
+class ExportRedirectsController extends CpController
+{
+    public function __invoke()
+    {
+        $this->authorize('index', Redirect::class);
+
+        $query = Facades\Redirect::query();
+
+        if (Site::multiEnabled()) {
+            $query->whereIn('site', Site::authorized()->map->handle()->all());
+        }
+
+        $path = tempnam(sys_get_temp_dir(), 'redirects-export-').'.csv';
+
+        $writer = SimpleExcelWriter::createWithoutBom($path);
+
+        $query->get()->each(function ($redirect) use ($writer) {
+            $writer->addRow([
+                'source' => $redirect->source(),
+                'destination' => $redirect->destination(),
+                'response_code' => $redirect->responseCode(),
+                'enabled' => $redirect->enabled() ? 'true' : 'false',
+                'description' => $redirect->get('description'),
+            ]);
+        });
+
+        $writer->close();
+
+        return response()->download($path, 'redirects.csv', [
+            'Content-Type' => 'text/csv',
+        ])->deleteFileAfterSend();
+    }
+}

--- a/src/Http/Controllers/CP/Redirects/ImportRedirectsController.php
+++ b/src/Http/Controllers/CP/Redirects/ImportRedirectsController.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Statamic\SeoPro\Http\Controllers\CP\Redirects;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Spatie\SimpleExcel\SimpleExcelReader;
+use Statamic\Facades\Site;
+use Statamic\Http\Controllers\CP\CpController;
+use Statamic\SeoPro\Facades;
+use Statamic\SeoPro\Redirects\Redirect;
+
+class ImportRedirectsController extends CpController
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        $this->authorize('create', Redirect::class);
+
+        $request->validate([
+            'file' => ['required', 'array', 'min:1'],
+        ]);
+
+        $path = Storage::disk('local')->path("statamic/file-uploads/{$request->file[0]}");
+
+        $reader = SimpleExcelReader::create($path);
+        $headers = collect($reader->getHeaders())->map(fn (string $header): string => (string) Str::of($header)->lower()->snake());
+        $rows = $reader->useHeaders($headers->all())->getRows();
+
+        if (! $headers->contains('source') || ! $headers->contains('destination')) {
+            return response()->json([
+                'message' => 'The CSV must have at least two columns: source, destination.',
+            ], 422);
+        }
+
+        $created = 0;
+        $updated = 0;
+        $site = Site::selected()->handle();
+        $defaultResponseCode = config('statamic.seo-pro.redirects.default_response_code', 301);
+
+        $rows->each(function (array $row) use ($headers, $site, $defaultResponseCode, &$created, &$updated) {
+            $source = trim($row['source'] ?? '');
+            $destination = trim($row['destination'] ?? '');
+
+            if (empty($source)) {
+                return;
+            }
+
+            $existingRedirect = Facades\Redirect::query()
+                ->where('source', $source)
+                ->where('site', $site)
+                ->first();
+
+            if ($existingRedirect) {
+                $existingRedirect->destination($destination);
+
+                if ($headers->contains('response_code')) {
+                    $existingRedirect->responseCode((int) $row['response_code'] ?: $defaultResponseCode);
+                }
+
+                if ($headers->contains('enabled')) {
+                    $existingRedirect->enabled(filter_var($row['enabled'], FILTER_VALIDATE_BOOLEAN));
+                }
+
+                if ($headers->contains('description') && $description = trim($row['description'])) {
+                    $existingRedirect->set('description', $description);
+                }
+
+                $existingRedirect->save();
+                $updated++;
+            } else {
+                $enabled = $headers->contains('enabled') ? filter_var($row['enabled'], FILTER_VALIDATE_BOOLEAN) : true;
+                $responseCode = $headers->contains('response_code') ? ((int) $row['response_code'] ?: $defaultResponseCode) : $defaultResponseCode;
+
+                $redirect = Facades\Redirect::make()
+                    ->site($site)
+                    ->source($source)
+                    ->destination($destination)
+                    ->responseCode($responseCode)
+                    ->enabled($enabled);
+
+                if ($headers->contains('description') && $description = trim($row['description'])) {
+                    $redirect->set('description', $description);
+                }
+
+                $redirect->save();
+                $created++;
+            }
+        });
+
+        Storage::disk('local')->delete("statamic/file-uploads/{$request->file[0]}");
+
+        return response()->json([
+            'created' => $created,
+            'updated' => $updated,
+        ]);
+    }
+}

--- a/src/Http/Controllers/CP/Redirects/RedirectController.php
+++ b/src/Http/Controllers/CP/Redirects/RedirectController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Statamic\SeoPro\Http\Controllers\CP;
+namespace Statamic\SeoPro\Http\Controllers\CP\Redirects;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;

--- a/tests/Redirects/ExportRedirectsTest.php
+++ b/tests/Redirects/ExportRedirectsTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Redirects;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Role;
+use Statamic\Facades\User;
+use Statamic\SeoPro\Facades;
+use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class ExportRedirectsTest extends TestCase
+{
+    use PreventsSavingStacheItemsToDisk;
+
+    #[Test]
+    public function can_export_redirects_as_csv()
+    {
+        Facades\Redirect::make()
+            ->id('one')
+            ->source('/old-url')
+            ->destination('/new-url')
+            ->responseCode(301)
+            ->enabled(true)
+            ->save();
+
+        Facades\Redirect::make()
+            ->id('two')
+            ->source('/another-old')
+            ->destination('/another-new')
+            ->responseCode(302)
+            ->enabled(false)
+            ->save();
+
+        $response = $this
+            ->actingAs(User::make()->makeSuper()->save())
+            ->get(cp_route('seo-pro.redirects.export'))
+            ->assertOk()
+            ->assertHeader('content-type', 'text/csv; charset=utf-8')
+            ->assertHeader('content-disposition', 'attachment; filename=redirects.csv');
+
+        $csv = $this->parseCsv($response->getFile()->getContent());
+
+        $this->assertCount(2, $csv);
+        $this->assertEquals('/old-url', $csv[0]['source']);
+        $this->assertEquals('/new-url', $csv[0]['destination']);
+        $this->assertEquals('301', $csv[0]['response_code']);
+        $this->assertEquals('true', $csv[0]['enabled']);
+        $this->assertEquals('/another-old', $csv[1]['source']);
+        $this->assertEquals('/another-new', $csv[1]['destination']);
+        $this->assertEquals('302', $csv[1]['response_code']);
+        $this->assertEquals('false', $csv[1]['enabled']);
+    }
+
+    #[Test]
+    public function export_includes_description()
+    {
+        $redirect = Facades\Redirect::make()
+            ->id('one')
+            ->source('/old-url')
+            ->destination('/new-url')
+            ->responseCode(301)
+            ->enabled(true);
+
+        $redirect->set('description', 'Legacy campaign URL');
+        $redirect->save();
+
+        $response = $this
+            ->actingAs(User::make()->makeSuper()->save())
+            ->get(cp_route('seo-pro.redirects.export'))
+            ->assertOk();
+
+        $csv = $this->parseCsv($response->getFile()->getContent());
+
+        $this->assertEquals('Legacy campaign URL', $csv[0]['description']);
+    }
+
+    #[Test]
+    public function cant_export_without_permission()
+    {
+        Role::make('test')->addPermission('access cp')->save();
+
+        $this
+            ->actingAs(User::make()->assignRole('test')->save())
+            ->get(cp_route('seo-pro.redirects.export'))
+            ->assertRedirect('/cp');
+    }
+
+    private function parseCsv(string $content): array
+    {
+        $lines = array_filter(explode("\n", trim($content)));
+        $headers = str_getcsv(array_shift($lines));
+
+        return array_map(function ($line) use ($headers) {
+            return array_combine($headers, str_getcsv($line));
+        }, $lines);
+    }
+}

--- a/tests/Redirects/ExportRedirectsTest.php
+++ b/tests/Redirects/ExportRedirectsTest.php
@@ -36,8 +36,7 @@ class ExportRedirectsTest extends TestCase
             ->actingAs(User::make()->makeSuper()->save())
             ->get(cp_route('seo-pro.redirects.export'))
             ->assertOk()
-            ->assertHeader('content-type', 'text/csv; charset=utf-8')
-            ->assertHeader('content-disposition', 'attachment; filename=redirects.csv');
+            ->assertDownload('redirects.csv');
 
         $csv = $this->parseCsv($response->getFile()->getContent());
 

--- a/tests/Redirects/ImportRedirectsTest.php
+++ b/tests/Redirects/ImportRedirectsTest.php
@@ -1,0 +1,249 @@
+<?php
+
+namespace Tests\Redirects;
+
+use Illuminate\Support\Facades\Storage;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Role;
+use Statamic\Facades\User;
+use Statamic\SeoPro\Facades;
+use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class ImportRedirectsTest extends TestCase
+{
+    use PreventsSavingStacheItemsToDisk;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake('local');
+    }
+
+    #[Test]
+    public function can_import_redirects_with_source_and_destination_only()
+    {
+        $this->uploadCsv("source,destination\n/old,/new\n/another-old,/another-new");
+
+        $this
+            ->actingAs(User::make()->makeSuper()->save())
+            ->postJson(cp_route('seo-pro.redirects.import'), ['file' => ['import.csv']])
+            ->assertOk()
+            ->assertJson(['created' => 2, 'updated' => 0]);
+
+        $redirect = Facades\Redirect::query()->where('source', '/old')->first();
+
+        $this->assertNotNull($redirect);
+        $this->assertEquals('/new', $redirect->destination());
+        $this->assertEquals(301, $redirect->responseCode());
+        $this->assertTrue($redirect->enabled());
+    }
+
+    #[Test]
+    public function can_import_redirects_with_all_columns()
+    {
+        $this->uploadCsv("source,destination,response_code,enabled,description\n/old,/new,302,false,Legacy page");
+
+        $this
+            ->actingAs(User::make()->makeSuper()->save())
+            ->postJson(cp_route('seo-pro.redirects.import'), ['file' => ['import.csv']])
+            ->assertOk()
+            ->assertJson(['created' => 1, 'updated' => 0]);
+
+        $redirect = Facades\Redirect::query()->where('source', '/old')->first();
+
+        $this->assertNotNull($redirect);
+        $this->assertEquals('/new', $redirect->destination());
+        $this->assertEquals(302, $redirect->responseCode());
+        $this->assertFalse($redirect->enabled());
+        $this->assertEquals('Legacy page', $redirect->get('description'));
+    }
+
+    #[Test]
+    public function import_updates_existing_redirects()
+    {
+        Facades\Redirect::make()
+            ->id('existing')
+            ->source('/old')
+            ->destination('/original')
+            ->responseCode(301)
+            ->enabled(true)
+            ->save();
+
+        $this->uploadCsv("source,destination\n/old,/updated");
+
+        $this
+            ->actingAs(User::make()->makeSuper()->save())
+            ->postJson(cp_route('seo-pro.redirects.import'), ['file' => ['import.csv']])
+            ->assertOk()
+            ->assertJson(['created' => 0, 'updated' => 1]);
+
+        $redirect = Facades\Redirect::find('existing');
+
+        $this->assertEquals('/updated', $redirect->destination());
+    }
+
+    #[Test]
+    public function import_preserves_existing_values_when_optional_columns_are_absent()
+    {
+        $existing = Facades\Redirect::make()
+            ->id('existing')
+            ->source('/old')
+            ->destination('/original')
+            ->responseCode(302)
+            ->enabled(false);
+
+        $existing->set('description', 'Keep this note');
+        $existing->save();
+
+        $this->uploadCsv("source,destination\n/old,/updated");
+
+        $this
+            ->actingAs(User::make()->makeSuper()->save())
+            ->postJson(cp_route('seo-pro.redirects.import'), ['file' => ['import.csv']])
+            ->assertOk();
+
+        $redirect = Facades\Redirect::find('existing');
+
+        $this->assertEquals('/updated', $redirect->destination());
+        $this->assertEquals(302, $redirect->responseCode());
+        $this->assertFalse($redirect->enabled());
+        $this->assertEquals('Keep this note', $redirect->get('description'));
+    }
+
+    #[Test]
+    public function import_overrides_values_when_optional_columns_are_present()
+    {
+        $existing = Facades\Redirect::make()
+            ->id('existing')
+            ->source('/old')
+            ->destination('/original')
+            ->responseCode(301)
+            ->enabled(true);
+
+        $existing->set('description', 'Old note');
+        $existing->save();
+
+        $this->uploadCsv("source,destination,response_code,enabled,description\n/old,/updated,302,false,New note");
+
+        $this
+            ->actingAs(User::make()->makeSuper()->save())
+            ->postJson(cp_route('seo-pro.redirects.import'), ['file' => ['import.csv']])
+            ->assertOk();
+
+        $redirect = Facades\Redirect::find('existing');
+
+        $this->assertEquals('/updated', $redirect->destination());
+        $this->assertEquals(302, $redirect->responseCode());
+        $this->assertFalse($redirect->enabled());
+        $this->assertEquals('New note', $redirect->get('description'));
+    }
+
+    #[Test]
+    public function import_skips_rows_with_empty_source()
+    {
+        $this->uploadCsv("source,destination\n,/new\n/valid,/destination");
+
+        $this
+            ->actingAs(User::make()->makeSuper()->save())
+            ->postJson(cp_route('seo-pro.redirects.import'), ['file' => ['import.csv']])
+            ->assertOk()
+            ->assertJson(['created' => 1, 'updated' => 0]);
+
+        $this->assertNull(Facades\Redirect::query()->where('source', '')->first());
+        $this->assertNotNull(Facades\Redirect::query()->where('source', '/valid')->first());
+    }
+
+    #[Test]
+    public function import_validates_file_is_required()
+    {
+        $this
+            ->actingAs(User::make()->makeSuper()->save())
+            ->postJson(cp_route('seo-pro.redirects.import'), ['file' => []])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('file');
+    }
+
+    #[Test]
+    public function import_validates_csv_has_required_headers()
+    {
+        $this->uploadCsv("url,target\n/old,/new");
+
+        $this
+            ->actingAs(User::make()->makeSuper()->save())
+            ->postJson(cp_route('seo-pro.redirects.import'), ['file' => ['import.csv']])
+            ->assertUnprocessable()
+            ->assertJson(['message' => 'The CSV must have at least two columns: source, destination.']);
+    }
+
+    #[Test]
+    public function cant_import_without_permission()
+    {
+        Role::make('test')->addPermission('access cp')->save();
+
+        $this->uploadCsv("source,destination\n/old,/new");
+
+        $this
+            ->actingAs(User::make()->assignRole('test')->save())
+            ->postJson(cp_route('seo-pro.redirects.import'), ['file' => ['import.csv']])
+            ->assertForbidden();
+
+        $this->assertNull(Facades\Redirect::query()->where('source', '/old')->first());
+    }
+
+    #[Test]
+    public function import_cleans_up_uploaded_file()
+    {
+        $this->uploadCsv("source,destination\n/old,/new");
+
+        $this
+            ->actingAs(User::make()->makeSuper()->save())
+            ->postJson(cp_route('seo-pro.redirects.import'), ['file' => ['import.csv']])
+            ->assertOk();
+
+        Storage::disk('local')->assertMissing('statamic/file-uploads/import.csv');
+    }
+
+    #[Test]
+    public function import_uses_configured_default_response_code()
+    {
+        config(['statamic.seo-pro.redirects.default_response_code' => 302]);
+
+        $this->uploadCsv("source,destination\n/old,/new");
+
+        $this
+            ->actingAs(User::make()->makeSuper()->save())
+            ->postJson(cp_route('seo-pro.redirects.import'), ['file' => ['import.csv']])
+            ->assertOk();
+
+        $redirect = Facades\Redirect::query()->where('source', '/old')->first();
+
+        $this->assertEquals(302, $redirect->responseCode());
+    }
+
+    #[Test]
+    public function import_handles_human_friendly_column_names()
+    {
+        $this->uploadCsv("Source,Destination,Response Code,Enabled,Description\n/old,/new,302,false,A note");
+
+        $this
+            ->actingAs(User::make()->makeSuper()->save())
+            ->postJson(cp_route('seo-pro.redirects.import'), ['file' => ['import.csv']])
+            ->assertOk()
+            ->assertJson(['created' => 1, 'updated' => 0]);
+
+        $redirect = Facades\Redirect::query()->where('source', '/old')->first();
+
+        $this->assertNotNull($redirect);
+        $this->assertEquals('/new', $redirect->destination());
+        $this->assertEquals(302, $redirect->responseCode());
+        $this->assertFalse($redirect->enabled());
+        $this->assertEquals('A note', $redirect->get('description'));
+    }
+
+    private function uploadCsv(string $content, string $filename = 'import.csv'): void
+    {
+        Storage::disk('local')->put("statamic/file-uploads/{$filename}", $content);
+    }
+}


### PR DESCRIPTION
This pull request adds the ability to import and export redirects.

## Exporting

Redirects can be exported from the "SEO Pro -> Redirects" page. They'll be exported in a `.csv` file:

<img width="432" height="149" alt="CleanShot 2026-05-05 at 10 37 09" src="https://github.com/user-attachments/assets/8216824d-3674-4ffc-9d22-4b11b6af7879" />

## Importing

Redirects can be imported from the "SEO Pro -> Redirects" page. The modal indicates which headers are accepted and how new/existing redirects will be handled:

<img width="686" height="458" alt="CleanShot 2026-05-05 at 10 38 20" src="https://github.com/user-attachments/assets/4b3e594f-7eb4-4518-ad12-5275e7dbf76f" />


---

Closes #549