### PR TITLE
Fix GenerateReportCommand not found when generating reports

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -59,8 +59,8 @@ class ServiceProvider extends AddonServiceProvider
 
     public function register()
     {
-        // Statamic discovers commands automatically, but when running in the console.
-        // We need to register this manually to call it in a web request.
+        // Statamic discovers commands automatically, but only when running in the console.
+        // To call this in a web request, we need to register it manually.
         $this->commands([GenerateReportCommand::class]);
 
         $this->registerSerializableClasses([

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -18,6 +18,7 @@ use Statamic\Facades\Permission;
 use Statamic\Facades\Site;
 use Statamic\Facades\User;
 use Statamic\Providers\AddonServiceProvider;
+use Statamic\SeoPro\Commands\GenerateReportCommand;
 use Statamic\SeoPro\Commands\PurgeErrorsCommand;
 use Statamic\SeoPro\Events\RedirectSaved;
 use Statamic\SeoPro\GraphQL\AlternateLocaleType;
@@ -58,6 +59,10 @@ class ServiceProvider extends AddonServiceProvider
 
     public function register()
     {
+        // Statamic discovers commands automatically, but when running in the console.
+        // We need to register this manually to call it in a web request.
+        $this->commands([GenerateReportCommand::class]);
+
         $this->registerSerializableClasses([
             Error::class,
             Page::class,


### PR DESCRIPTION
This pull request fixes an issue where clicking "Generate Report" in the Control Panel throws a `CommandNotFoundException` for `statamic:seo-pro:generate-report`.

This was happening because Statamic's `AddonServiceProvider` only auto-discovers commands when `runningInConsole()` is true. When the report is generated via a web request (using `Artisan::queue` with the `sync` queue driver), the command was never registered.

This PR fixes it by explicitly registering `GenerateReportCommand` in the service provider's `register()` method, which runs regardless of context.

Fixes #556