### PR TITLE
Fix empty IDs for redirects & tracked 404 errors

### DIFF
--- a/src/Redirects/Stache/ErrorRepository.php
+++ b/src/Redirects/Stache/ErrorRepository.php
@@ -74,7 +74,7 @@ class ErrorRepository implements RepositoryContract
             return $slug;
         }
 
-        return 'error-'.substr(sha1($url), 0, 10);
+        return $this->stache->generateId();
     }
 
     public function blueprint(): Blueprint

--- a/src/Redirects/Stache/ErrorRepository.php
+++ b/src/Redirects/Stache/ErrorRepository.php
@@ -50,8 +50,7 @@ class ErrorRepository implements RepositoryContract
         }
 
         if (! $error->id()) {
-            $slug = Str::slug($error->url());
-            $id = $slug;
+            $id = $slug = $this->generateId($error->url());
             $suffix = 1;
 
             while ($this->query()->where('id', $id)->where('site', $error->site())->first()) {
@@ -67,6 +66,15 @@ class ErrorRepository implements RepositoryContract
     public function delete(Error $error): void
     {
         $this->store->delete($error);
+    }
+
+    protected function generateId(string $url): string
+    {
+        if ($slug = Str::slug($url)) {
+            return $slug;
+        }
+
+        return 'error-'.substr(sha1($url), 0, 10);
     }
 
     public function blueprint(): Blueprint

--- a/src/Redirects/Stache/ErrorRepository.php
+++ b/src/Redirects/Stache/ErrorRepository.php
@@ -68,7 +68,7 @@ class ErrorRepository implements RepositoryContract
         $this->store->delete($error);
     }
 
-    protected function generateId(string $url): string
+    private function generateId(string $url): string
     {
         if ($slug = Str::slug($url)) {
             return $slug;

--- a/src/Redirects/Stache/RedirectRepository.php
+++ b/src/Redirects/Stache/RedirectRepository.php
@@ -74,7 +74,7 @@ class RedirectRepository implements RepositoryContract
             return $slug;
         }
 
-        return 'redirect-'.substr(sha1($source), 0, 10);
+        return $this->stache->generateId();
     }
 
     public function blueprint(): Blueprint

--- a/src/Redirects/Stache/RedirectRepository.php
+++ b/src/Redirects/Stache/RedirectRepository.php
@@ -50,8 +50,7 @@ class RedirectRepository implements RepositoryContract
         }
 
         if (! $redirect->id()) {
-            $slug = Str::slug($redirect->source());
-            $id = $slug;
+            $id = $slug = $this->generateId($redirect->source());
             $suffix = 1;
 
             while ($this->query()->where('id', $id)->where('site', $redirect->site())->first()) {
@@ -67,6 +66,15 @@ class RedirectRepository implements RepositoryContract
     public function delete(Redirect $redirect): void
     {
         $this->store->delete($redirect);
+    }
+
+    private function generateId(string $source): string
+    {
+        if ($slug = Str::slug($source)) {
+            return $slug;
+        }
+
+        return 'redirect-'.substr(sha1($source), 0, 10);
     }
 
     public function blueprint(): Blueprint

--- a/tests/Redirects/Stache/ErrorRepositoryTest.php
+++ b/tests/Redirects/Stache/ErrorRepositoryTest.php
@@ -76,6 +76,20 @@ class ErrorRepositoryTest extends TestCase
     }
 
     #[Test]
+    public function it_generates_a_hashed_id_when_url_cannot_be_slugged()
+    {
+        $error = Facades\Error::make()
+            ->url('/)')
+            ->hits(1)
+            ->lastHitAt('2026-04-21 12:00:00');
+
+        $this->repo->save($error);
+
+        $this->assertEquals('error-'.substr(sha1('/)'), 0, 10), $error->id());
+        $this->assertStringContainsString('errors/'.$error->id().'.yaml', $error->path());
+    }
+
+    #[Test]
     public function it_appends_suffix_when_generated_id_already_exists()
     {
         Facades\Error::make()

--- a/tests/Redirects/Stache/ErrorRepositoryTest.php
+++ b/tests/Redirects/Stache/ErrorRepositoryTest.php
@@ -7,6 +7,7 @@ use Statamic\Facades\YAML;
 use Statamic\SeoPro\Facades;
 use Statamic\SeoPro\Redirects\Error;
 use Statamic\SeoPro\Redirects\Stache\ErrorRepository;
+use Statamic\Support\Str;
 use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
 use Tests\TestCase;
 
@@ -76,7 +77,7 @@ class ErrorRepositoryTest extends TestCase
     }
 
     #[Test]
-    public function it_generates_a_hashed_id_when_url_cannot_be_slugged()
+    public function it_generates_a_uuid_id_when_url_cannot_be_slugged()
     {
         $error = Facades\Error::make()
             ->url('/)')
@@ -85,7 +86,7 @@ class ErrorRepositoryTest extends TestCase
 
         $this->repo->save($error);
 
-        $this->assertEquals('error-'.substr(sha1('/)'), 0, 10), $error->id());
+        $this->assertTrue(Str::isUuid($error->id()));
         $this->assertStringContainsString('errors/'.$error->id().'.yaml', $error->path());
     }
 

--- a/tests/Redirects/Stache/RedirectRepositoryTest.php
+++ b/tests/Redirects/Stache/RedirectRepositoryTest.php
@@ -81,6 +81,21 @@ class RedirectRepositoryTest extends TestCase
     }
 
     #[Test]
+    public function it_generates_a_hashed_id_when_source_cannot_be_slugged()
+    {
+        $redirect = Facades\Redirect::make()
+            ->source('/)')
+            ->destination('/new-url')
+            ->responseCode(301)
+            ->enabled(true);
+
+        $this->repo->save($redirect);
+
+        $this->assertEquals('redirect-'.substr(sha1('/)'), 0, 10), $redirect->id());
+        $this->assertStringContainsString('redirects/'.$redirect->id().'.yaml', $redirect->path());
+    }
+
+    #[Test]
     public function it_appends_suffix_when_generated_id_already_exists()
     {
         Facades\Redirect::make()

--- a/tests/Redirects/Stache/RedirectRepositoryTest.php
+++ b/tests/Redirects/Stache/RedirectRepositoryTest.php
@@ -7,6 +7,7 @@ use Statamic\Facades\YAML;
 use Statamic\SeoPro\Facades;
 use Statamic\SeoPro\Redirects\Redirect;
 use Statamic\SeoPro\Redirects\Stache\RedirectRepository;
+use Statamic\Support\Str;
 use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
 use Tests\TestCase;
 
@@ -81,7 +82,7 @@ class RedirectRepositoryTest extends TestCase
     }
 
     #[Test]
-    public function it_generates_a_hashed_id_when_source_cannot_be_slugged()
+    public function it_generates_a_uuid_id_when_source_cannot_be_slugged()
     {
         $redirect = Facades\Redirect::make()
             ->source('/)')
@@ -91,7 +92,7 @@ class RedirectRepositoryTest extends TestCase
 
         $this->repo->save($redirect);
 
-        $this->assertEquals('redirect-'.substr(sha1('/)'), 0, 10), $redirect->id());
+        $this->assertTrue(Str::isUuid($redirect->id()));
         $this->assertStringContainsString('redirects/'.$redirect->id().'.yaml', $redirect->path());
     }
 


### PR DESCRIPTION
## Summary

- falls back to a deterministic hash-based ID when a tracked 404 URL cannot be slugged
- keeps existing slug-based IDs for normal URLs
- adds regression coverage for malformed URLs like `/)`

Fixes #558.

## Testing

- `./vendor/bin/phpunit tests/Redirects/Stache/ErrorRepositoryTest.php tests/Redirects/RecordErrorTest.php`
- `./vendor/bin/pint --test src/Redirects/Stache/ErrorRepository.php tests/Redirects/Stache/ErrorRepositoryTest.php`