### PR TITLE
Prevent SEO Pro's site filter from overriding the one in core

### DIFF
--- a/src/Query/Scopes/Filters/Site.php
+++ b/src/Query/Scopes/Filters/Site.php
@@ -11,6 +11,8 @@ class Site extends Filter
 {
     protected $pinned = true;
 
+    protected static $handle = 'seo_pro_site';
+
     public static function title()
     {
         return __('Site');


### PR DESCRIPTION
This pull request fixes an issue where SEO Pro's site filter (introduced recently for the redirects feature) was overriding the one in core due to conflicting handles.

Fixes #560
