### PR TITLE
Add prefix to Stache store keys

### DIFF
--- a/src/Redirects/Error.php
+++ b/src/Redirects/Error.php
@@ -98,7 +98,7 @@ class Error
 
     public function buildPath(): string
     {
-        $directory = rtrim(Stache::store('errors')->directory(), '/');
+        $directory = rtrim(Stache::store('seo_pro_errors')->directory(), '/');
 
         if (Site::multiEnabled()) {
             return $directory.'/'.$this->site().'/'.$this->id().'.yaml';

--- a/src/Redirects/Redirect.php
+++ b/src/Redirects/Redirect.php
@@ -145,7 +145,7 @@ class Redirect
 
     public function buildPath(): string
     {
-        $directory = rtrim(Stache::store('redirects')->directory(), '/');
+        $directory = rtrim(Stache::store('seo_pro_redirects')->directory(), '/');
 
         if (Site::multiEnabled()) {
             return $directory.'/'.$this->site().'/'.$this->id().'.yaml';

--- a/src/Redirects/Stache/ErrorQueryBuilder.php
+++ b/src/Redirects/Stache/ErrorQueryBuilder.php
@@ -30,7 +30,7 @@ class ErrorQueryBuilder extends Builder implements QueryBuilder
     protected function getKeysWithWhere($where)
     {
         $items = app('stache')
-            ->store('errors')
+            ->store('seo_pro_errors')
             ->index($where['column'])->items();
 
         $method = 'filterWhere'.$where['type'];

--- a/src/Redirects/Stache/ErrorRepository.php
+++ b/src/Redirects/Stache/ErrorRepository.php
@@ -20,7 +20,7 @@ class ErrorRepository implements RepositoryContract
     public function __construct(Stache $stache)
     {
         $this->stache = $stache;
-        $this->store = $stache->store('errors');
+        $this->store = $stache->store('seo_pro_errors');
     }
 
     public function all(): Collection

--- a/src/Redirects/Stache/ErrorsStore.php
+++ b/src/Redirects/Stache/ErrorsStore.php
@@ -20,7 +20,7 @@ class ErrorsStore extends BasicStore
 
     public function key()
     {
-        return 'errors';
+        return 'seo_pro_errors';
     }
 
     public function makeItemFromFile($path, $contents): Error

--- a/src/Redirects/Stache/RedirectQueryBuilder.php
+++ b/src/Redirects/Stache/RedirectQueryBuilder.php
@@ -30,7 +30,7 @@ class RedirectQueryBuilder extends Builder implements QueryBuilder
     protected function getKeysWithWhere($where)
     {
         $items = app('stache')
-            ->store('redirects')
+            ->store('seo_pro_redirects')
             ->index($where['column'])->items();
 
         $method = 'filterWhere'.$where['type'];

--- a/src/Redirects/Stache/RedirectRepository.php
+++ b/src/Redirects/Stache/RedirectRepository.php
@@ -20,7 +20,7 @@ class RedirectRepository implements RepositoryContract
     public function __construct(Stache $stache)
     {
         $this->stache = $stache;
-        $this->store = $stache->store('redirects');
+        $this->store = $stache->store('seo_pro_redirects');
     }
 
     public function all(): Collection

--- a/src/Redirects/Stache/RedirectsStore.php
+++ b/src/Redirects/Stache/RedirectsStore.php
@@ -20,7 +20,7 @@ class RedirectsStore extends BasicStore
 
     public function key()
     {
-        return 'redirects';
+        return 'seo_pro_redirects';
     }
 
     public function makeItemFromFile($path, $contents): Redirect

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -206,24 +206,24 @@ class ServiceProvider extends AddonServiceProvider
         ]);
 
         $this->app->bind(Redirects\Stache\ErrorQueryBuilder::class, function () {
-            return new Redirects\Stache\ErrorQueryBuilder($this->app->make(Stache::class)->store('errors'));
+            return new Redirects\Stache\ErrorQueryBuilder($this->app->make(Stache::class)->store('seo_pro_errors'));
         });
 
         $this->app->bind(Redirects\Stache\RedirectQueryBuilder::class, function () {
-            return new Redirects\Stache\RedirectQueryBuilder($this->app->make(Stache::class)->store('redirects'));
+            return new Redirects\Stache\RedirectQueryBuilder($this->app->make(Stache::class)->store('seo_pro_redirects'));
         });
 
         Statamic::repository(ErrorRepository::class, Redirects\Stache\ErrorRepository::class);
         Statamic::repository(RedirectRepository::class, Redirects\Stache\RedirectRepository::class);
 
         if (config('statamic.seo-pro.redirects.driver') === 'database') {
-            $this->app['stache']->exclude('redirects');
+            $this->app['stache']->exclude('seo_pro_redirects');
 
             Statamic::repository(RedirectRepository::class, Redirects\Eloquent\RedirectRepository::class);
         }
 
         if (config('statamic.seo-pro.redirects.errors.driver') === 'database') {
-            $this->app['stache']->exclude('errors');
+            $this->app['stache']->exclude('seo_pro_errors');
 
             Statamic::repository(ErrorRepository::class, Redirects\Eloquent\ErrorRepository::class);
         }
@@ -341,7 +341,7 @@ class ServiceProvider extends AddonServiceProvider
                 $this->components->task(
                     description: 'Updating redirects',
                     task: function () {
-                        $base = app(Stache::class)->store('redirects')->directory();
+                        $base = app(Stache::class)->store('seo_pro_redirects')->directory();
 
                         File::makeDirectory("{$base}/{$this->siteHandle}");
 
@@ -357,7 +357,7 @@ class ServiceProvider extends AddonServiceProvider
                 $this->components->task(
                     description: 'Updating errors',
                     task: function () {
-                        $base = app(Stache::class)->store('errors')->directory();
+                        $base = app(Stache::class)->store('seo_pro_errors')->directory();
 
                         File::makeDirectory("{$base}/{$this->siteHandle}");
 

--- a/tests/Redirects/Stache/ErrorsStoreTest.php
+++ b/tests/Redirects/Stache/ErrorsStoreTest.php
@@ -21,7 +21,7 @@ class ErrorsStoreTest extends TestCase
     {
         parent::setUp();
 
-        $this->store = app('stache')->store('errors');
+        $this->store = app('stache')->store('seo_pro_errors');
         $this->directory = config('statamic.seo-pro.redirects.errors.directory');
     }
 

--- a/tests/Redirects/Stache/RedirectsStoreTest.php
+++ b/tests/Redirects/Stache/RedirectsStoreTest.php
@@ -21,7 +21,7 @@ class RedirectsStoreTest extends TestCase
     {
         parent::setUp();
 
-        $this->store = app('stache')->store('redirects');
+        $this->store = app('stache')->store('seo_pro_redirects');
         $this->directory = config('statamic.seo-pro.redirects.directory');
     }
 


### PR DESCRIPTION
This pull request adds a prefix (`seo_pro_`) to the keys of our Stache stores to avoid conflicts with third-party addons. 

Related: https://github.com/riasvdv/statamic-redirect/issues/294