### PR TITLE
Fix broken SEO preview images

### DIFF
--- a/resources/js/components/fieldtypes/PreviewsFieldtype.vue
+++ b/resources/js/components/fieldtypes/PreviewsFieldtype.vue
@@ -19,14 +19,7 @@ const resolveSeoValue = (field) => {
 	let value = publishValues.value.seo[field];
 
 	if (value.source === 'inherit') {
-		let seoField = publishMeta.value.seo.fields.find(f => f.handle === field);
-		let placeholder = placeholders.value[field];
-
-		if (seoField.field?.type === 'assets' && placeholder) {
-			return props.meta.assetContainerUrl + '/' + placeholder;
-		}
-
-		return placeholder;
+		return placeholders.value[field];
 	}
 
 	if (value.source === 'field') {

--- a/src/Fieldtypes/Concerns/ResolvesPlaceholders.php
+++ b/src/Fieldtypes/Concerns/ResolvesPlaceholders.php
@@ -42,7 +42,7 @@ trait ResolvesPlaceholders
 
             return collect($cascade)->map(function ($value) {
                 if ($value instanceof Asset) {
-                    return $value->path();
+                    return $value->id();
                 }
 
                 if ($value instanceof Collection) {

--- a/src/Fieldtypes/SeoProPreviews.php
+++ b/src/Fieldtypes/SeoProPreviews.php
@@ -10,7 +10,6 @@ use Statamic\Contracts\Entries\Entry;
 use Statamic\Contracts\Taxonomies\Taxonomy;
 use Statamic\Contracts\Taxonomies\Term;
 use Statamic\Facades\Antlers;
-use Statamic\Facades\AssetContainer;
 use Statamic\Facades\Site;
 use Statamic\Fields\Fieldtype;
 use Statamic\SeoPro\Fieldtypes\Concerns\ResolvesPlaceholders;
@@ -27,9 +26,6 @@ class SeoProPreviews extends Fieldtype
             'initialUrl' => $this->field->parent()?->absoluteUrl(),
             'routeFields' => Antlers::identifiers($this->getRouteString()),
             'previewUrl' => cp_route('seo-pro.preview'),
-            'assetContainerUrl' => config('statamic.seo-pro.assets.container')
-                ? AssetContainer::find(config('statamic.seo-pro.assets.container'))->url()
-                : null,
             'faviconUrl' => $this->faviconUrl(),
             'placeholders' => $this->getPlaceholders(),
         ];

--- a/src/Http/Controllers/CP/PreviewController.php
+++ b/src/Http/Controllers/CP/PreviewController.php
@@ -38,7 +38,9 @@ class PreviewController extends CpController
 
     private function transformImage(string $preset, string $assetId): ?string
     {
-        $asset = Asset::find($assetId);
+        if (! $asset = Asset::find($assetId)) {
+            return null;
+        }
 
         if (array_key_exists($preset, Image::customManipulationPresets())) {
             $glide = Statamic::tag('glide:generate')


### PR DESCRIPTION
SEO preview images are currently broken when an entry's `seo.image` inherits from an asset  container that's different from the one configured in `seo-pro.assets.container`.

Right now, `ResolvesPlaceholders` serializes inherited values via `$value->path()` which misses the actual asset container. `PreviewsFieldtype.vue` concatenates the container from the config onto that path and sent the resulting URL string to `PreviewController`. There, `Asset::find()` only accepts `container::path` IDs (which is what `field` and `custom` already send). The result is returning `null` and `null` then getting passed to Glide.

Using `id` instead of `path` preserves all the information to build valid image URLs.

Closes https://github.com/statamic/seo-pro/issues/565.

Also thanks to Ivan who pointed this out through support.