### PR TITLE
Ensure source is pre-filled when creating redirect from error

### DIFF
--- a/src/Http/Controllers/CP/Redirects/RedirectController.php
+++ b/src/Http/Controllers/CP/Redirects/RedirectController.php
@@ -108,7 +108,12 @@ class RedirectController extends CpController
 
         $blueprint = Facades\Redirect::blueprint();
 
-        $fields = $blueprint->fields()->preProcess();
+        $fields = $blueprint
+            ->fields()
+            ->addValues(array_filter([
+                'source' => $request->query('source'),
+            ]))
+            ->preProcess();
 
         return Inertia::render('seo-pro::Redirects/Create', [
             'blueprint' => $blueprint->toPublishArray(),

--- a/tests/Redirects/CreateRedirectTest.php
+++ b/tests/Redirects/CreateRedirectTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Redirects;
 
+use Inertia\Testing\AssertableInertia;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Role;
@@ -34,5 +35,19 @@ class CreateRedirectTest extends TestCase
             ->actingAs(User::make()->assignRole('test')->save())
             ->get(cp_route('seo-pro.redirects.create'))
             ->assertRedirect('/cp');
+    }
+
+    #[Test]
+    public function source_query_parameter_is_prepopulated()
+    {
+        Collection::make('pages')->save();
+
+        $this
+            ->actingAs(User::make()->makeSuper()->save())
+            ->get(cp_route('seo-pro.redirects.create', ['source' => '/broken-url']))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->where('values.source', '/broken-url')
+            );
     }
 }


### PR DESCRIPTION
This PR fixes an issue where the source field wasn't being pre-filled when creating a redirect from an error. We were passing the URL as a query parameter, we just weren't using it.

Fixes #574
