### PR TITLE
Fix duplicate Stache IDs for errors/redirects on multi-site installs

### DIFF
--- a/src/Redirects/Stache/ErrorsStore.php
+++ b/src/Redirects/Stache/ErrorsStore.php
@@ -23,6 +23,15 @@ class ErrorsStore extends BasicStore
         return 'seo_pro_errors';
     }
 
+    public function getItemKey($item)
+    {
+        if (Site::multiEnabled()) {
+            return $item->site().'::'.$item->id();
+        }
+
+        return $item->id();
+    }
+
     public function makeItemFromFile($path, $contents): Error
     {
         $data = YAML::file($path)->parse($contents);

--- a/src/Redirects/Stache/ErrorsStore.php
+++ b/src/Redirects/Stache/ErrorsStore.php
@@ -18,12 +18,12 @@ class ErrorsStore extends BasicStore
         'id', 'site', 'url', 'hits', 'last_hit_at',
     ];
 
-    public function key()
+    public function key(): string
     {
         return 'seo_pro_errors';
     }
 
-    public function getItemKey($item)
+    public function getItemKey($item): string
     {
         if (Site::multiEnabled()) {
             return $item->site().'::'.$item->id();
@@ -59,7 +59,7 @@ class ErrorsStore extends BasicStore
         return $site;
     }
 
-    public function getItemFilter(SplFileInfo $file)
+    public function getItemFilter(SplFileInfo $file): bool
     {
         return $file->getExtension() === 'yaml';
     }

--- a/src/Redirects/Stache/RedirectsStore.php
+++ b/src/Redirects/Stache/RedirectsStore.php
@@ -23,6 +23,15 @@ class RedirectsStore extends BasicStore
         return 'seo_pro_redirects';
     }
 
+    public function getItemKey($item)
+    {
+        if (Site::multiEnabled()) {
+            return $item->site().'::'.$item->id();
+        }
+
+        return $item->id();
+    }
+
     public function makeItemFromFile($path, $contents): Redirect
     {
         $data = YAML::file($path)->parse($contents);

--- a/src/Redirects/Stache/RedirectsStore.php
+++ b/src/Redirects/Stache/RedirectsStore.php
@@ -18,12 +18,12 @@ class RedirectsStore extends BasicStore
         'id', 'site', 'source', 'enabled', 'hits',
     ];
 
-    public function key()
+    public function key(): string
     {
         return 'seo_pro_redirects';
     }
 
-    public function getItemKey($item)
+    public function getItemKey($item): string
     {
         if (Site::multiEnabled()) {
             return $item->site().'::'.$item->id();
@@ -62,7 +62,7 @@ class RedirectsStore extends BasicStore
         return $site;
     }
 
-    public function getItemFilter(SplFileInfo $file)
+    public function getItemFilter(SplFileInfo $file): bool
     {
         return $file->getExtension() === 'yaml';
     }

--- a/tests/Redirects/Stache/ErrorsStoreTest.php
+++ b/tests/Redirects/Stache/ErrorsStoreTest.php
@@ -88,6 +88,7 @@ class ErrorsStoreTest extends TestCase
     public function it_returns_composite_key_for_multisite()
     {
         config(['statamic.system.multisite' => true]);
+
         Site::setSites([
             'en' => ['url' => 'http://test.com/', 'locale' => 'en_US'],
             'fr' => ['url' => 'http://test.com/fr/', 'locale' => 'fr_FR'],
@@ -104,6 +105,7 @@ class ErrorsStoreTest extends TestCase
     public function it_extracts_site_from_multisite_path()
     {
         config(['statamic.system.multisite' => true]);
+
         Site::setSites([
             'en' => ['url' => 'http://test.com/', 'locale' => 'en_US'],
             'fr' => ['url' => 'http://test.com/fr/', 'locale' => 'fr_FR'],

--- a/tests/Redirects/Stache/ErrorsStoreTest.php
+++ b/tests/Redirects/Stache/ErrorsStoreTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Redirects\Stache;
 
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Site;
 use Statamic\SeoPro\Facades;
 use Statamic\SeoPro\Redirects\Error;
 use Statamic\Stache\Stores\Store;
@@ -71,5 +72,49 @@ class ErrorsStoreTest extends TestCase
         $this->assertStringEqualsFile($path, $error->fileContents());
         @unlink($path);
         $this->assertFileDoesNotExist($path);
+    }
+
+    #[Test]
+    public function it_returns_id_as_item_key_for_single_site()
+    {
+        $error = Facades\Error::make()->id('abc')->site('en')->url('/broken-link');
+
+        $key = $this->store->getItemKey($error);
+
+        $this->assertEquals('abc', $key);
+    }
+
+    #[Test]
+    public function it_returns_composite_key_for_multisite()
+    {
+        config(['statamic.system.multisite' => true]);
+        Site::setSites([
+            'en' => ['url' => 'http://test.com/', 'locale' => 'en_US'],
+            'fr' => ['url' => 'http://test.com/fr/', 'locale' => 'fr_FR'],
+        ]);
+
+        $errorEn = Facades\Error::make()->id('abc')->site('en')->url('/broken-link');
+        $errorFr = Facades\Error::make()->id('abc')->site('fr')->url('/broken-link');
+
+        $this->assertEquals('en::abc', $this->store->getItemKey($errorEn));
+        $this->assertEquals('fr::abc', $this->store->getItemKey($errorFr));
+    }
+
+    #[Test]
+    public function it_extracts_site_from_multisite_path()
+    {
+        config(['statamic.system.multisite' => true]);
+        Site::setSites([
+            'en' => ['url' => 'http://test.com/', 'locale' => 'en_US'],
+            'fr' => ['url' => 'http://test.com/fr/', 'locale' => 'fr_FR'],
+        ]);
+
+        $item = $this->store->makeItemFromFile(
+            $this->store->directory().'fr/abc.yaml',
+            "url: /broken-link\nhits: 5",
+        );
+
+        $this->assertEquals('abc', $item->id());
+        $this->assertEquals('fr', $item->site());
     }
 }

--- a/tests/Redirects/Stache/RedirectsStoreTest.php
+++ b/tests/Redirects/Stache/RedirectsStoreTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Redirects\Stache;
 
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Site;
 use Statamic\SeoPro\Facades;
 use Statamic\SeoPro\Redirects\Redirect;
 use Statamic\Stache\Stores\Store;
@@ -74,5 +75,53 @@ class RedirectsStoreTest extends TestCase
         $this->assertStringEqualsFile($path, $redirect->fileContents());
         @unlink($path);
         $this->assertFileDoesNotExist($path);
+    }
+
+    #[Test]
+    public function it_returns_id_as_item_key_for_single_site()
+    {
+        $redirect = Facades\Redirect::make()
+            ->id('abc')
+            ->site('en')
+            ->source('/old-url')
+            ->destination('/new-url');
+
+        $key = $this->store->getItemKey($redirect);
+
+        $this->assertEquals('abc', $key);
+    }
+
+    #[Test]
+    public function it_returns_composite_key_for_multisite()
+    {
+        config(['statamic.system.multisite' => true]);
+        Site::setSites([
+            'en' => ['url' => 'http://test.com/', 'locale' => 'en_US'],
+            'fr' => ['url' => 'http://test.com/fr/', 'locale' => 'fr_FR'],
+        ]);
+
+        $redirectEn = Facades\Redirect::make()->id('abc')->site('en')->source('/old');
+        $redirectFr = Facades\Redirect::make()->id('abc')->site('fr')->source('/old');
+
+        $this->assertEquals('en::abc', $this->store->getItemKey($redirectEn));
+        $this->assertEquals('fr::abc', $this->store->getItemKey($redirectFr));
+    }
+
+    #[Test]
+    public function it_extracts_site_from_multisite_path()
+    {
+        config(['statamic.system.multisite' => true]);
+        Site::setSites([
+            'en' => ['url' => 'http://test.com/', 'locale' => 'en_US'],
+            'fr' => ['url' => 'http://test.com/fr/', 'locale' => 'fr_FR'],
+        ]);
+
+        $item = $this->store->makeItemFromFile(
+            $this->store->directory().'fr/abc.yaml',
+            "source: /old-url\ndestination: /new-url",
+        );
+
+        $this->assertEquals('abc', $item->id());
+        $this->assertEquals('fr', $item->site());
     }
 }

--- a/tests/Redirects/Stache/RedirectsStoreTest.php
+++ b/tests/Redirects/Stache/RedirectsStoreTest.php
@@ -95,6 +95,7 @@ class RedirectsStoreTest extends TestCase
     public function it_returns_composite_key_for_multisite()
     {
         config(['statamic.system.multisite' => true]);
+
         Site::setSites([
             'en' => ['url' => 'http://test.com/', 'locale' => 'en_US'],
             'fr' => ['url' => 'http://test.com/fr/', 'locale' => 'fr_FR'],
@@ -111,6 +112,7 @@ class RedirectsStoreTest extends TestCase
     public function it_extracts_site_from_multisite_path()
     {
         config(['statamic.system.multisite' => true]);
+
         Site::setSites([
             'en' => ['url' => 'http://test.com/', 'locale' => 'en_US'],
             'fr' => ['url' => 'http://test.com/fr/', 'locale' => 'fr_FR'],


### PR DESCRIPTION
This pull request fixes an issue where errors and redirects with the same slug across different sites were treated as duplicates in Stache.

This was happening because Statamic's `GetSlugFromPath` utility only extracts the filename from the path, discarding the site directory. Files like `errors/cs/console.yaml` and `errors/da/console.yaml` both ended up with the same Stache key `console`.

This PR fixes it by overriding `getItemKey()` in both `ErrorsStore` and `RedirectsStore` to return composite keys (`{site}::{id}`) when multi-site is enabled. This follows the same pattern used by Statamic core's `TaxonomyTermsStore` and `NavTreeStore`.

Fixes #573