### PR TITLE
Fix breadcrumb schema positions to start at 1 instead of 0

### DIFF
--- a/src/Cascade.php
+++ b/src/Cascade.php
@@ -629,7 +629,7 @@ class Cascade
                 'itemListElement' => $breadcrumbs->map(function ($crumb, $index) {
                     return [
                         '@type' => 'ListItem',
-                        'position' => $index,
+                        'position' => $index + 1,
                         'name' => $crumb->get('title'),
                         'item' => $crumb->absoluteUrl(),
                     ];

--- a/tests/CascadeTest.php
+++ b/tests/CascadeTest.php
@@ -519,7 +519,7 @@ class CascadeTest extends TestCase
 
         $this->assertEquals([
             '{"@context":"https://schema.org","@type":"Person","name":"Derice Bannock","@id":"http://cool-runnings.com#person","url":"http://cool-runnings.com"}',
-            '{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":0,"name":"Home","item":"http://cool-runnings.com"},{"@type":"ListItem","position":1,"name":"\'Dance Like No One is Watching\' Is Bad Advice","item":"http://cool-runnings.com/dance"}]}',
+            '{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"http://cool-runnings.com"},{"@type":"ListItem","position":2,"name":"\'Dance Like No One is Watching\' Is Bad Advice","item":"http://cool-runnings.com/dance"}]}',
         ], $data['json_ld']->all());
     }
 }


### PR DESCRIPTION
This pull request fixes an issue where the BreadcrumbList JSON-LD schema generated positions starting at 0, which doesn't comply with Schema.org or Google's structured data specifications.

This was happening because the `$index` from the `map()` callback was used directly for the position value, which is 0-indexed in PHP.

This PR fixes it by adding 1 to the index, so positions now correctly start at 1.

Fixes #579