### PR TITLE
Fix missing horizontal padding in SEO Pro widget

### DIFF
--- a/resources/js/components/widgets/SeoProWidget.vue
+++ b/resources/js/components/widgets/SeoProWidget.vue
@@ -15,7 +15,7 @@ defineProps({
 			<Button :href="reportsUrl" size="sm" :text="__('seo-pro::messages.view_reports')" />
 		</template>
 
-		<div v-if="report" class="flex flex-col items-center justify-center gap-4" style="min-height: 159px">
+		<div v-if="report" class="flex flex-col items-center justify-center gap-4 px-4" style="min-height: 159px">
 			<h2
 				class="!text-4xl leading-tight font-light"
 				:class="{
@@ -29,7 +29,7 @@ defineProps({
 			<Description :text="__('seo-pro::messages.latest_report_score')" />
 		</div>
 
-		<div v-else class="flex flex-col items-center justify-center gap-4" style="min-height: 159px">
+		<div v-else class="flex flex-col items-center justify-center gap-4 px-4" style="min-height: 159px">
 			<Description :text="__('seo-pro::messages.report_no_results_text')" />
 			<Button :href="createUrl" variant="primary" :text="__('seo-pro::messages.generate_your_first_report')" />
 		</div>


### PR DESCRIPTION
This pull request fixes an issue where the SEO Pro widget's default text had no horizontal padding, causing it to touch the widget border when displayed at narrow widths.

This was happening because the container divs for both the report score and "no reports" states didn't have any horizontal padding applied.

This PR fixes it by adding `px-4` padding to both container states, ensuring consistent spacing regardless of widget width or browser viewport size.

## Before

<img width="415" height="247" alt="CleanShot 2026-05-26 at 09 47 08" src="https://github.com/user-attachments/assets/4b871bc5-b14d-459d-bfd8-73de32e719a4" />


## After

<img width="415" height="247" alt="CleanShot 2026-05-26 at 09 47 23" src="https://github.com/user-attachments/assets/0cd0882b-172d-4895-91e9-46a395235fd4" />



---

Fixes #580