### PR TITLE
Fix policy compatibility with Eloquent user repository

### DIFF
--- a/src/Policies/ErrorPolicy.php
+++ b/src/Policies/ErrorPolicy.php
@@ -17,6 +17,6 @@ class ErrorPolicy
 
     public function index($user): bool
     {
-        return $user->hasPermission('view seo redirects');
+        return User::fromUser($user)->hasPermission('view seo redirects');
     }
 }

--- a/src/Policies/RedirectPolicy.php
+++ b/src/Policies/RedirectPolicy.php
@@ -23,31 +23,31 @@ class RedirectPolicy
 
     public function view($user): bool
     {
-        return $user->hasPermission('view seo redirects');
+        return User::fromUser($user)->hasPermission('view seo redirects');
     }
 
     public function create($user): bool
     {
-        return $user->hasPermission('create seo redirects');
+        return User::fromUser($user)->hasPermission('create seo redirects');
     }
 
     public function store($user): bool
     {
-        return $user->hasPermission('create seo redirects');
+        return User::fromUser($user)->hasPermission('create seo redirects');
     }
 
     public function edit($user, Redirect $redirect): bool
     {
-        return $user->hasPermission('edit seo redirects');
+        return User::fromUser($user)->hasPermission('edit seo redirects');
     }
 
     public function update($user, Redirect $redirect): bool
     {
-        return $user->hasPermission('edit seo redirects');
+        return User::fromUser($user)->hasPermission('edit seo redirects');
     }
 
     public function delete($user, Redirect $redirect): bool
     {
-        return $user->hasPermission('delete seo redirects');
+        return User::fromUser($user)->hasPermission('delete seo redirects');
     }
 }


### PR DESCRIPTION
This pull request fixes an issue where non-superadmin users with SEO Pro permissions would get a `BadMethodCallException` when accessing the redirects feature while using the Eloquent user repository.

This was happening because the `RedirectPolicy` and `ErrorPolicy` classes only wrapped the user with `User::fromUser()` in the `before()` method. When that method returned `null` (for non-super users), the subsequent permission methods received the raw Laravel user model, which doesn't have the `hasPermission()` method.

This PR fixes it by wrapping the user with `User::fromUser()` in each permission-checking method, ensuring the Statamic user contract is always used.

Fixes #584