### PR TITLE
Make `og:type` configurable

### DIFF
--- a/lang/en/fieldsets/content.php
+++ b/lang/en/fieldsets/content.php
@@ -52,6 +52,9 @@ return [
     'image' => 'Social Image',
     'image_instruct' => 'This image is used as a social network preview image.',
 
+    'og_type' => 'Open Graph Type',
+    'og_type_instruct' => 'The type of content (eg. website, article). [Learn more](https://ogp.me/#types)',
+
     'og_title' => 'Open Graph Title',
     'og_title_instruct' => 'Pick an existing field or custom value to set as your Open Graph title.',
 

--- a/lang/en/fieldsets/defaults.php
+++ b/lang/en/fieldsets/defaults.php
@@ -69,6 +69,9 @@ return [
     'image' => 'Image',
     'image_instruct' => 'Choose a default image field to represent each URL when shared on social networks.',
 
+    'og_type' => 'Open Graph Type',
+    'og_type_instruct' => 'The type of content (eg. website, article). [Learn more](https://ogp.me/#types)',
+
     'og_title' => 'Open Graph Title',
     'og_title_instruct' => 'Choose the field for your Open Graph titles.',
 

--- a/lang/en/fieldsets/sections.php
+++ b/lang/en/fieldsets/sections.php
@@ -54,6 +54,9 @@ return [
     'og_section' => 'Open Graph',
     'og_section_instruct' => 'We automatically generate most Open Graph fields from your meta data and site configuration.',
 
+    'og_type' => 'Open Graph Type',
+    'og_type_instruct' => 'The default type of content for this section (eg. website, article). [Learn more](https://ogp.me/#types)',
+
     'og_title' => 'Open Graph Title',
     'og_title_instruct' => 'Pick an existing field or custom value to set as your Open Graph title.',
 

--- a/resources/views/meta.antlers.html
+++ b/resources/views/meta.antlers.html
@@ -10,7 +10,7 @@
     <meta name="robots" content="{{ robots | raw | list | striptags | entities | trim }}" />
 {{ /if }}
 
-<meta property="og:type" content="website" />
+<meta property="og:type" content="{{ og_type | striptags | entities | trim }}" />
 
 {{ if og_title }}
     <meta property="og:title" content="{{ og_title | striptags | entities | trim }}" />

--- a/src/Cascade.php
+++ b/src/Cascade.php
@@ -121,6 +121,7 @@ class Cascade
 
         return $this->data->merge([
             'compiled_title' => $this->compiledTitle(),
+            'og_type' => $this->data->get('og_type') ?: 'website',
             'og_title' => $this->ogTitle(),
             'canonical_url' => $this->canonicalUrl(),
             'prev_url' => $this->prevUrl(),

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -308,6 +308,21 @@ class Fields
                 'instructions' => __('seo-pro::fieldsets/defaults.image_section_instruct'),
                 'fields' => [
                     [
+                        'handle' => 'og_type',
+                        'field' => [
+                            'display' => __("seo-pro::fieldsets/{$langFile}.og_type"),
+                            'instructions' => __("seo-pro::fieldsets/{$langFile}.og_type_instruct"),
+                            'type' => 'seo_pro_source',
+                            'from_field' => false,
+                            'localizable' => true,
+                            'field' => [
+                                'type' => 'text',
+                            ],
+                            'always_save' => true,
+                            'unless' => ['enabled' => 'equals false'],
+                        ],
+                    ],
+                    [
                         'handle' => 'og_title',
                         'field' => [
                             'display' => __("seo-pro::fieldsets/{$langFile}.og_title"),

--- a/src/SiteDefaults/Blueprint.php
+++ b/src/SiteDefaults/Blueprint.php
@@ -260,6 +260,16 @@ class Blueprint
                         [
                             'fields' => [
                                 [
+                                    'handle' => 'og_type',
+                                    'field' => [
+                                        'display' => __('seo-pro::fieldsets/defaults.og_type'),
+                                        'instructions' => __('seo-pro::fieldsets/defaults.og_type_instruct'),
+                                        'type' => 'text',
+                                        'localizable' => true,
+                                        'default' => 'website',
+                                    ],
+                                ],
+                                [
                                     'handle' => 'og_title',
                                     'field' => [
                                         'display' => __('seo-pro::fieldsets/defaults.og_title'),

--- a/src/SiteDefaults/SiteDefaults.php
+++ b/src/SiteDefaults/SiteDefaults.php
@@ -85,6 +85,7 @@ class SiteDefaults
             'title' => '@seo:title',
             'description' => '@seo:content',
             'canonical_url' => '@seo:permalink',
+            'og_type' => 'website',
             'priority' => 0.5,
             'change_frequency' => 'monthly',
         ];


### PR DESCRIPTION
This pull request makes the `og:type` meta tag configurable through the cascade system.

Previously, `og:type` was hardcoded to "website" in the meta template. This PR makes it configurable at the site, section, or entry level, allowing users to set appropriate types like "article" for blog posts.

The field defaults to "website" to maintain backwards compatibility.

Closes #586