### PR TITLE
Fix breadcrumb JSON-LD null names for localized entries

### DIFF
--- a/src/Cascade.php
+++ b/src/Cascade.php
@@ -654,7 +654,7 @@ class Cascade
                     return [
                         '@type' => 'ListItem',
                         'position' => $index + 1,
-                        'name' => $crumb->get('title'),
+                        'name' => $crumb->value('title'),
                         'item' => $crumb->absoluteUrl(),
                     ];
                 })->all(),


### PR DESCRIPTION
This pull request fixes an issue where breadcrumb JSON-LD structured data rendered with `"name": null` for localized entries that inherit their title from the origin site.

This was happening because `get('title')` was used to retrieve the breadcrumb name, which returns the raw field value. For localized entries that inherit their title, Statamic stores this as `null` (deduplicating the override on save).

This PR fixes it by using `value('title')` instead, which leverages Statamic's value resolution system to properly resolve inherited values.

Fixes #591