### PR TITLE
Fix view scenario test isolation

### DIFF
--- a/tests/ViewScenarios.php
+++ b/tests/ViewScenarios.php
@@ -20,7 +20,17 @@ trait ViewScenarios
 
     public function prepareViews($viewType)
     {
+        $this->cleanUpViews();
+
         $this->files->copyDirectory(__DIR__.'/Fixtures/views/'.$viewType, resource_path('views-seo-pro'));
+
+        // Clear compiled view cache to ensure fresh compilation with correct component paths
+        $compiledPath = config('view.compiled');
+        if ($compiledPath && $this->files->isDirectory($compiledPath)) {
+            foreach ($this->files->files($compiledPath) as $file) {
+                $this->files->delete($file);
+            }
+        }
 
         return $this;
     }

--- a/tests/ViewScenarios.php
+++ b/tests/ViewScenarios.php
@@ -24,8 +24,8 @@ trait ViewScenarios
 
         $this->files->copyDirectory(__DIR__.'/Fixtures/views/'.$viewType, resource_path('views-seo-pro'));
 
-        // Clear compiled view cache to ensure fresh compilation with correct component paths
         $compiledPath = config('view.compiled');
+
         if ($compiledPath && $this->files->isDirectory($compiledPath)) {
             foreach ($this->files->files($compiledPath) as $file) {
                 $this->files->delete($file);


### PR DESCRIPTION
## Summary
- Fix test isolation issue in `ViewScenarios` trait that caused flaky test failures
- Clean up view fixtures directory before copying new fixtures to prevent file leakage between scenarios
- Clear compiled view cache to ensure fresh Blade compilation with correct component paths

## Context
Tests were failing because:
1. View fixtures from previous scenarios (antlers → blade → blade-components) were leaking into subsequent ones since `copyDirectory` is additive and does not clean the destination first
2. Laravel compiled view cache was persisting stale component resolution paths between test iterations

## Test plan
- [x] All 425 tests pass (1 intentionally skipped)
- [x] Confirmed consistent results across multiple test runs

🤖 Generated with [Claude Code](https://claude.ai/code)