### PR TITLE
Fix automatic redirects for Eloquent stored entries

### DIFF
--- a/src/Redirects/AutomaticRedirectSubscriber.php
+++ b/src/Redirects/AutomaticRedirectSubscriber.php
@@ -36,7 +36,7 @@ class AutomaticRedirectSubscriber
         }
 
         $newSlug = $entry->slug();
-        $originalSlug = $this->originalEntrySlug($entry);
+        $originalSlug = $this->getOriginalEntrySlug($entry);
 
         if (! $originalSlug || $originalSlug === $newSlug) {
             return;
@@ -230,7 +230,14 @@ class AutomaticRedirectSubscriber
         return $path ?: '/';
     }
 
-    private function originalEntrySlug($entry): ?string
+    private function shouldHandleEntry($entry): bool
+    {
+        $collections = config('statamic.seo-pro.redirects.automatic_redirects.collections', []);
+
+        return in_array('*', $collections) || in_array($entry->collectionHandle(), $collections);
+    }
+
+    private function getOriginalEntrySlug($entry): ?string
     {
         if ($initialPath = $entry->initialPath()) {
             $slug = pathinfo($initialPath, PATHINFO_FILENAME);
@@ -239,13 +246,6 @@ class AutomaticRedirectSubscriber
         }
 
         return $entry->getOriginal('slug');
-    }
-
-    private function shouldHandleEntry($entry): bool
-    {
-        $collections = config('statamic.seo-pro.redirects.automatic_redirects.collections', []);
-
-        return in_array('*', $collections) || in_array($entry->collectionHandle(), $collections);
     }
 
     private function shouldHandleTerm($term): bool

--- a/src/Redirects/AutomaticRedirectSubscriber.php
+++ b/src/Redirects/AutomaticRedirectSubscriber.php
@@ -35,17 +35,10 @@ class AutomaticRedirectSubscriber
             return;
         }
 
-        $initialPath = $entry->initialPath();
-
-        if (! $initialPath || $initialPath === $entry->buildPath()) {
-            return;
-        }
-
         $newSlug = $entry->slug();
-        $originalSlug = pathinfo($initialPath, PATHINFO_FILENAME);
-        $originalSlug = preg_replace('/^\d{4}-\d{2}-\d{2}(-\d{4,6})?\./', '', $originalSlug);
+        $originalSlug = $this->originalEntrySlug($entry);
 
-        if ($originalSlug === $newSlug) {
+        if (! $originalSlug || $originalSlug === $newSlug) {
             return;
         }
 
@@ -235,6 +228,17 @@ class AutomaticRedirectSubscriber
         }
 
         return $path ?: '/';
+    }
+
+    private function originalEntrySlug($entry): ?string
+    {
+        if ($initialPath = $entry->initialPath()) {
+            $slug = pathinfo($initialPath, PATHINFO_FILENAME);
+
+            return preg_replace('/^\d{4}-\d{2}-\d{2}(-\d{4,6})?\./', '', $slug);
+        }
+
+        return $entry->getOriginal('slug');
     }
 
     private function shouldHandleEntry($entry): bool

--- a/src/Redirects/AutomaticRedirectSubscriber.php
+++ b/src/Redirects/AutomaticRedirectSubscriber.php
@@ -239,6 +239,8 @@ class AutomaticRedirectSubscriber
 
     private function getOriginalEntrySlug($entry): ?string
     {
+        // ->getOriginal('slug') doesn't work reliably for entries stored
+        // in the Stache, so we need to use the initialPath instead.
         if ($initialPath = $entry->initialPath()) {
             $slug = pathinfo($initialPath, PATHINFO_FILENAME);
 


### PR DESCRIPTION
When collections/entries are stored in the db using the Eloquent driver, automatic redirects are not getting created when the slug changes.

Since the current `initialPath()` check is a flat file agnostic, Eloquent entries are never loaded and `initialPath()` is always null so the handler returns early before caching the original URL. The result is that no redirect gets created.

This introduces a small helper that's storage-agnostic and resolve the previous slug to make automatic redirects work properly.