### PR TITLE
Fix error when generating JSON-LD breadcrumbs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         }
     },
     "require": {
-        "statamic/cms": "^6.10",
+        "statamic/cms": "^6.19",
         "pixelfear/composer-dist-plugin": "^0.1.6",
         "spatie/simple-excel": "^3.9"
     },

--- a/src/Cascade.php
+++ b/src/Cascade.php
@@ -654,7 +654,7 @@ class Cascade
                     return [
                         '@type' => 'ListItem',
                         'position' => $index + 1,
-                        'name' => method_exists($crumb, 'value') ? $crumb->value('title') : $crumb->get('title'),
+                        'name' => $crumb->title,
                         'item' => $crumb->absoluteUrl(),
                     ];
                 })->all(),

--- a/src/Cascade.php
+++ b/src/Cascade.php
@@ -654,7 +654,7 @@ class Cascade
                     return [
                         '@type' => 'ListItem',
                         'position' => $index + 1,
-                        'name' => $crumb->value('title'),
+                        'name' => method_exists($crumb, 'value') ? $crumb->value('title') : $crumb->get('title'),
                         'item' => $crumb->absoluteUrl(),
                     ];
                 })->all(),

--- a/tests/CascadeTest.php
+++ b/tests/CascadeTest.php
@@ -539,34 +539,31 @@ class CascadeTest extends TestCase
             ->get();
 
         $breadcrumbs = collect($data['json_ld'])->first(fn ($snippet) => str_contains($snippet, 'BreadcrumbList'));
+        $breadcrumbs = json_decode($breadcrumbs, true);
 
-        $this->assertNotNull($breadcrumbs);
-
-        $decoded = json_decode($breadcrumbs, true);
-
-        $this->assertEquals('BreadcrumbList', $decoded['@type']);
-        $this->assertCount(3, $decoded['itemListElement']);
+        $this->assertEquals('BreadcrumbList', $breadcrumbs['@type']);
+        $this->assertCount(3, $breadcrumbs['itemListElement']);
 
         $this->assertEquals([
             '@type' => 'ListItem',
             'position' => 1,
             'name' => 'Home',
             'item' => 'http://cool-runnings.com',
-        ], $decoded['itemListElement'][0]);
+        ], $breadcrumbs['itemListElement'][0]);
 
         $this->assertEquals([
             '@type' => 'ListItem',
             'position' => 2,
             'name' => 'Articles',
             'item' => 'http://cool-runnings.com/articles',
-        ], $decoded['itemListElement'][1]);
+        ], $breadcrumbs['itemListElement'][1]);
 
         $this->assertEquals([
             '@type' => 'ListItem',
             'position' => 3,
             'name' => "'Dance Like No One is Watching' Is Bad Advice",
             'item' => 'http://cool-runnings.com/articles/dance',
-        ], $decoded['itemListElement'][2]);
+        ], $breadcrumbs['itemListElement'][2]);
     }
 
     #[Test]
@@ -586,33 +583,30 @@ class CascadeTest extends TestCase
             ->get();
 
         $breadcrumbs = collect($data['json_ld'])->first(fn ($snippet) => str_contains($snippet, 'BreadcrumbList'));
+        $breadcrumbs = json_decode($breadcrumbs, true);
 
-        $this->assertNotNull($breadcrumbs);
-
-        $decoded = json_decode($breadcrumbs, true);
-
-        $this->assertEquals('BreadcrumbList', $decoded['@type']);
-        $this->assertCount(3, $decoded['itemListElement']);
+        $this->assertEquals('BreadcrumbList', $breadcrumbs['@type']);
+        $this->assertCount(3, $breadcrumbs['itemListElement']);
 
         $this->assertEquals([
             '@type' => 'ListItem',
             'position' => 1,
             'name' => 'Home',
             'item' => 'http://cool-runnings.com',
-        ], $decoded['itemListElement'][0]);
+        ], $breadcrumbs['itemListElement'][0]);
 
         $this->assertEquals([
             '@type' => 'ListItem',
             'position' => 2,
             'name' => 'Topics',
             'item' => 'http://cool-runnings.com/topics',
-        ], $decoded['itemListElement'][1]);
+        ], $breadcrumbs['itemListElement'][1]);
 
         $this->assertEquals([
             '@type' => 'ListItem',
             'position' => 3,
             'name' => 'Sneakers',
             'item' => 'http://cool-runnings.com/topics/sneakers',
-        ], $decoded['itemListElement'][2]);
+        ], $breadcrumbs['itemListElement'][2]);
     }
 }

--- a/tests/CascadeTest.php
+++ b/tests/CascadeTest.php
@@ -522,4 +522,97 @@ class CascadeTest extends TestCase
             '{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"http://cool-runnings.com"},{"@type":"ListItem","position":2,"name":"\'Dance Like No One is Watching\' Is Bad Advice","item":"http://cool-runnings.com/dance"}]}',
         ], $data['json_ld']->all());
     }
+
+    #[Test]
+    public function it_generates_json_ld_breadcrumbs_for_entry()
+    {
+        Collection::findByHandle('articles')->routes('articles/{slug}')->save();
+
+        $siteDefaults = SiteDefaults::in('default')->set([
+            'json_ld_breadcrumbs' => true,
+        ]);
+
+        $this->get('/articles/dance');
+
+        $data = (new Cascade)
+            ->with($siteDefaults->all())
+            ->get();
+
+        $breadcrumbs = collect($data['json_ld'])->first(fn ($snippet) => str_contains($snippet, 'BreadcrumbList'));
+
+        $this->assertNotNull($breadcrumbs);
+
+        $decoded = json_decode($breadcrumbs, true);
+
+        $this->assertEquals('BreadcrumbList', $decoded['@type']);
+        $this->assertCount(3, $decoded['itemListElement']);
+
+        $this->assertEquals([
+            '@type' => 'ListItem',
+            'position' => 1,
+            'name' => 'Home',
+            'item' => 'http://cool-runnings.com',
+        ], $decoded['itemListElement'][0]);
+
+        $this->assertEquals([
+            '@type' => 'ListItem',
+            'position' => 2,
+            'name' => 'Articles',
+            'item' => 'http://cool-runnings.com/articles',
+        ], $decoded['itemListElement'][1]);
+
+        $this->assertEquals([
+            '@type' => 'ListItem',
+            'position' => 3,
+            'name' => "'Dance Like No One is Watching' Is Bad Advice",
+            'item' => 'http://cool-runnings.com/articles/dance',
+        ], $decoded['itemListElement'][2]);
+    }
+
+    #[Test]
+    public function it_generates_json_ld_breadcrumbs_for_taxonomy_term()
+    {
+        $siteDefaults = SiteDefaults::in('default')->set([
+            'json_ld_breadcrumbs' => true,
+        ]);
+
+        $this->files->makeDirectory(resource_path('views/topics'), force: true);
+        $this->files->put(resource_path('views/topics/index.antlers.html'), '');
+
+        $this->get('/topics/sneakers');
+
+        $data = (new Cascade)
+            ->with($siteDefaults->all())
+            ->get();
+
+        $breadcrumbs = collect($data['json_ld'])->first(fn ($snippet) => str_contains($snippet, 'BreadcrumbList'));
+
+        $this->assertNotNull($breadcrumbs);
+
+        $decoded = json_decode($breadcrumbs, true);
+
+        $this->assertEquals('BreadcrumbList', $decoded['@type']);
+        $this->assertCount(3, $decoded['itemListElement']);
+
+        $this->assertEquals([
+            '@type' => 'ListItem',
+            'position' => 1,
+            'name' => 'Home',
+            'item' => 'http://cool-runnings.com',
+        ], $decoded['itemListElement'][0]);
+
+        $this->assertEquals([
+            '@type' => 'ListItem',
+            'position' => 2,
+            'name' => 'Topics',
+            'item' => 'http://cool-runnings.com/topics',
+        ], $decoded['itemListElement'][1]);
+
+        $this->assertEquals([
+            '@type' => 'ListItem',
+            'position' => 3,
+            'name' => 'Sneakers',
+            'item' => 'http://cool-runnings.com/topics/sneakers',
+        ], $decoded['itemListElement'][2]);
+    }
 }

--- a/tests/Localized/CascadeTest.php
+++ b/tests/Localized/CascadeTest.php
@@ -84,14 +84,11 @@ class CascadeTest extends LocalizedTestCase
             ->get();
 
         $breadcrumbs = collect($data['json_ld'])->first(fn ($snippet) => str_contains($snippet, 'BreadcrumbList'));
+        $breadcrumbs = json_decode($breadcrumbs, true);
 
-        $this->assertNotNull($breadcrumbs);
+        $this->assertEquals('BreadcrumbList', $breadcrumbs['@type']);
 
-        $decoded = json_decode($breadcrumbs, true);
-
-        $this->assertEquals('BreadcrumbList', $decoded['@type']);
-
-        $lastItem = end($decoded['itemListElement']);
+        $lastItem = end($breadcrumbs['itemListElement']);
         $this->assertEquals('About', $lastItem['name']);
         $this->assertEquals('http://cool-runnings.com/fr/about', $lastItem['item']);
     }

--- a/tests/Localized/CascadeTest.php
+++ b/tests/Localized/CascadeTest.php
@@ -67,4 +67,44 @@ class CascadeTest extends LocalizedTestCase
             'it' => 'http://corse-fantastiche.it',
         ], collect($data['alternate_locales'])->pluck('url', 'hreflang')->all());
     }
+
+    #[Test]
+    public function it_generates_json_ld_breadcrumbs_for_entry_using_title_from_origin()
+    {
+        // The French /about entry has an origin but no title set,
+        // so it should use the origin entry's title in breadcrumbs
+        $siteDefaults = SiteDefaults::in('french')->set([
+            'json_ld_breadcrumbs' => true,
+        ]);
+
+        $this->get('http://cool-runnings.com/fr/about');
+
+        $data = (new Cascade)
+            ->with($siteDefaults->all())
+            ->get();
+
+        $breadcrumbs = collect($data['json_ld'])->first(fn ($snippet) => str_contains($snippet, 'BreadcrumbList'));
+
+        $this->assertNotNull($breadcrumbs);
+
+        $decoded = json_decode($breadcrumbs, true);
+
+        $this->assertEquals('BreadcrumbList', $decoded['@type']);
+        $this->assertCount(2, $decoded['itemListElement']);
+
+        $this->assertEquals([
+            '@type' => 'ListItem',
+            'position' => 1,
+            'name' => 'Home',
+            'item' => 'http://cool-runnings.com/fr',
+        ], $decoded['itemListElement'][0]);
+
+        // The localized entry has no title, so it should use the origin's title
+        $this->assertEquals([
+            '@type' => 'ListItem',
+            'position' => 2,
+            'name' => 'About',
+            'item' => 'http://cool-runnings.com/fr/about',
+        ], $decoded['itemListElement'][1]);
+    }
 }

--- a/tests/Localized/CascadeTest.php
+++ b/tests/Localized/CascadeTest.php
@@ -90,21 +90,9 @@ class CascadeTest extends LocalizedTestCase
         $decoded = json_decode($breadcrumbs, true);
 
         $this->assertEquals('BreadcrumbList', $decoded['@type']);
-        $this->assertCount(2, $decoded['itemListElement']);
 
-        $this->assertEquals([
-            '@type' => 'ListItem',
-            'position' => 1,
-            'name' => 'Home',
-            'item' => 'http://cool-runnings.com/fr',
-        ], $decoded['itemListElement'][0]);
-
-        // The localized entry has no title, so it should use the origin's title
-        $this->assertEquals([
-            '@type' => 'ListItem',
-            'position' => 2,
-            'name' => 'About',
-            'item' => 'http://cool-runnings.com/fr/about',
-        ], $decoded['itemListElement'][1]);
+        $lastItem = end($decoded['itemListElement']);
+        $this->assertEquals('About', $lastItem['name']);
+        $this->assertEquals('http://cool-runnings.com/fr/about', $lastItem['item']);
     }
 }

--- a/tests/Localized/CascadeTest.php
+++ b/tests/Localized/CascadeTest.php
@@ -71,8 +71,6 @@ class CascadeTest extends LocalizedTestCase
     #[Test]
     public function it_generates_json_ld_breadcrumbs_for_entry_using_title_from_origin()
     {
-        // The French /about entry has an origin but no title set,
-        // so it should use the origin entry's title in breadcrumbs
         $siteDefaults = SiteDefaults::in('french')->set([
             'json_ld_breadcrumbs' => true,
         ]);


### PR DESCRIPTION
This pull request fixes an error when generating JSON-LD breadcrumbs. 

We swapped `->get()` for `->value()` in #592 to ensure we resolve the origin title when a localization doesn't have its own title.

However, the `->value()` method doesn't exist on the `Taxonomy` class, leading to errors when viewing a taxonomy index or term page.

This PR fixes it by calling the `title` property instead which resolves the title appropriately via augmentation. This PR also adds tests to cover JSON-LD breadcrumbs.

Fixes #598