### PR TITLE
Add section default events & invalidate static cache

### DIFF
--- a/src/Events/CollectionDefaultsSaved.php
+++ b/src/Events/CollectionDefaultsSaved.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Statamic\SeoPro\Events;
+
+use Statamic\Contracts\Entries\Collection;
+use Statamic\Events\Event;
+
+class CollectionDefaultsSaved extends Event
+{
+    public function __construct(public Collection $collection) {}
+}

--- a/src/Events/TaxonomyDefaultsSaved.php
+++ b/src/Events/TaxonomyDefaultsSaved.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Statamic\SeoPro\Events;
+
+use Statamic\Contracts\Taxonomies\Taxonomy;
+use Statamic\Events\Event;
+
+class TaxonomyDefaultsSaved extends Event
+{
+    public function __construct(public Taxonomy $taxonomy) {}
+}

--- a/src/Http/Controllers/CP/BaseSectionDefaultsController.php
+++ b/src/Http/Controllers/CP/BaseSectionDefaultsController.php
@@ -8,6 +8,8 @@ use Statamic\Contracts\Taxonomies\Taxonomy;
 use Statamic\CP\PublishForm;
 use Statamic\Facades\Blueprint;
 use Statamic\Http\Controllers\CP\CpController;
+use Statamic\SeoPro\Events\CollectionDefaultsSaved;
+use Statamic\SeoPro\Events\TaxonomyDefaultsSaved;
 use Statamic\SeoPro\Fields;
 use Statamic\Support\Arr;
 
@@ -77,6 +79,12 @@ abstract class BaseSectionDefaultsController extends CpController
         }
 
         $item->cascade($cascade->all())->save();
+
+        if ($item instanceof Collection) {
+            CollectionDefaultsSaved::dispatch($item);
+        } elseif ($item instanceof Taxonomy) {
+            TaxonomyDefaultsSaved::dispatch($item);
+        }
 
         if ($disabled) {
             $this->removeChildSeo($item);

--- a/src/Listeners/InvalidateStaticCache.php
+++ b/src/Listeners/InvalidateStaticCache.php
@@ -4,20 +4,25 @@ namespace Statamic\SeoPro\Listeners;
 
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Statamic\Facades\URL;
+use Statamic\SeoPro\Events\CollectionDefaultsSaved;
 use Statamic\SeoPro\Events\SiteDefaultsSaved;
+use Statamic\SeoPro\Events\TaxonomyDefaultsSaved;
 use Statamic\StaticCaching\Cacher;
+use Statamic\StaticCaching\Invalidator;
 use Statamic\Support\Arr;
 
 class InvalidateStaticCache implements ShouldQueue
 {
     private string|array $rules;
 
-    public function __construct(private Cacher $cacher)
-    {
+    public function __construct(
+        private Cacher $cacher,
+        private Invalidator $invalidator
+    ) {
         $this->rules = config('statamic.static_caching.invalidation.rules', []);
     }
 
-    public function handle(SiteDefaultsSaved $event): void
+    public function handleSiteDefaultsSaved(SiteDefaultsSaved $event): void
     {
         if (! config('statamic.static_caching.strategy')) {
             return;
@@ -41,5 +46,37 @@ class InvalidateStaticCache implements ShouldQueue
             ...$absoluteUrls,
             ...$prefixedRelativeUrls,
         ]);
+    }
+
+    public function handleCollectionDefaultsSaved(CollectionDefaultsSaved $event): void
+    {
+        if (! config('statamic.static_caching.strategy')) {
+            return;
+        }
+
+        if ($this->rules === 'all') {
+            $this->cacher->flush();
+
+            return;
+        }
+
+        $this->invalidator->invalidate($event->collection);
+    }
+
+    public function handleTaxonomyDefaultsSaved(TaxonomyDefaultsSaved $event): void
+    {
+        if (! config('statamic.static_caching.strategy')) {
+            return;
+        }
+
+        if ($this->rules === 'all') {
+            $this->cacher->flush();
+
+            return;
+        }
+
+        $event->taxonomy->queryTerms()->get()->each(function ($term) {
+            $this->invalidator->invalidate($term);
+        });
     }
 }

--- a/tests/StaticCachingInvalidationTest.php
+++ b/tests/StaticCachingInvalidationTest.php
@@ -4,9 +4,14 @@ namespace Tests;
 
 use Mockery;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Collection;
 use Statamic\Facades\Site;
+use Statamic\Facades\Taxonomy;
+use Statamic\SeoPro\Events\CollectionDefaultsSaved;
+use Statamic\SeoPro\Events\TaxonomyDefaultsSaved;
 use Statamic\SeoPro\SiteDefaults\SiteDefaults;
 use Statamic\StaticCaching\Cacher;
+use Statamic\StaticCaching\Invalidator;
 
 class StaticCachingInvalidationTest extends TestCase
 {
@@ -95,5 +100,92 @@ class StaticCachingInvalidationTest extends TestCase
         ]);
 
         SiteDefaults::in('fr')->save();
+    }
+
+    #[Test]
+    public function does_nothing_for_collection_defaults_when_static_caching_is_disabled()
+    {
+        $invalidator = Mockery::mock(Invalidator::class);
+        $invalidator->shouldReceive('invalidate')->never();
+
+        $this->app->bind(Invalidator::class, fn () => $invalidator);
+
+        config()->set('statamic.static_caching.strategy', null);
+
+        $collection = Collection::find('pages');
+
+        CollectionDefaultsSaved::dispatch($collection);
+    }
+
+    #[Test]
+    public function flushes_static_cache_when_collection_defaults_are_saved_with_all_rules()
+    {
+        $invalidator = Mockery::mock(Invalidator::class);
+        $invalidator->shouldReceive('invalidate')->never();
+
+        $this->app->bind(Invalidator::class, fn () => $invalidator);
+
+        config()->set('statamic.static_caching.invalidation.rules', 'all');
+
+        $collection = Collection::find('pages');
+
+        CollectionDefaultsSaved::dispatch($collection);
+    }
+
+    #[Test]
+    public function invalidates_collection_when_collection_defaults_are_saved()
+    {
+        $collection = Collection::find('pages');
+
+        $invalidator = Mockery::mock(Invalidator::class);
+        $invalidator->shouldReceive('invalidate')->withArgs(function ($item) use ($collection) {
+            return $item->handle() === $collection->handle();
+        })->once();
+
+        $this->app->bind(Invalidator::class, fn () => $invalidator);
+
+        CollectionDefaultsSaved::dispatch($collection);
+    }
+
+    #[Test]
+    public function does_nothing_for_taxonomy_defaults_when_static_caching_is_disabled()
+    {
+        $invalidator = Mockery::mock(Invalidator::class);
+        $invalidator->shouldReceive('invalidate')->never();
+
+        $this->app->bind(Invalidator::class, fn () => $invalidator);
+
+        config()->set('statamic.static_caching.strategy', null);
+
+        $taxonomy = Taxonomy::find('topics');
+
+        TaxonomyDefaultsSaved::dispatch($taxonomy);
+    }
+
+    #[Test]
+    public function flushes_static_cache_when_taxonomy_defaults_are_saved_with_all_rules()
+    {
+        $cacher = Mockery::mock(Cacher::class)->shouldReceive('flush')->once()->getMock();
+
+        $this->app->bind(Cacher::class, fn () => $cacher);
+
+        config()->set('statamic.static_caching.invalidation.rules', 'all');
+
+        $taxonomy = Taxonomy::find('topics');
+
+        TaxonomyDefaultsSaved::dispatch($taxonomy);
+    }
+
+    #[Test]
+    public function invalidates_terms_when_taxonomy_defaults_are_saved()
+    {
+        $taxonomy = Taxonomy::find('topics');
+
+        $invalidator = Mockery::mock(Invalidator::class);
+        $invalidator->shouldReceive('invalidate')->times($taxonomy->queryTerms()->count());
+
+        $this->app->bind(Invalidator::class, fn () => $invalidator);
+
+        TaxonomyDefaultsSaved::dispatch($taxonomy);
     }
 }


### PR DESCRIPTION
This pull request adds events for when collection/taxonomy section defaults are updated, similar to the `SiteDefaultsSaved` event we have for site defaults.

This PR also ensures that the configured URLs are invalidated when section defaults are updated. It will use the existing `collections` and `taxonomies` invalidation rules.

Fixes https://github.com/statamic/seo-pro/issues/595