### PR TITLE
Add "Disabled" option to JSON-LD entity type

### DIFF
--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -74,6 +74,7 @@ return [
     'never' => 'Never',
     'organization' => 'Organization',
     'person' => 'Person',
+    'disabled' => 'Disabled',
     'test_redirect' => 'Test Redirect',
     'enabled' => 'Enabled',
     'active' => 'Active',

--- a/src/SiteDefaults/Blueprint.php
+++ b/src/SiteDefaults/Blueprint.php
@@ -112,6 +112,7 @@ class Blueprint
                                         'options' => [
                                             'organization' => __('seo-pro::messages.organization'),
                                             'person' => __('seo-pro::messages.person'),
+                                            'disabled' => __('seo-pro::messages.disabled'),
                                         ],
                                         'default' => 'organization',
                                     ],


### PR DESCRIPTION
This pull request adds a "Disabled" option to the JSON-LD entity type selector in Site Defaults.

Previously, the entity type only offered "Organization" or "Person" options. Developers wanting full control over their JSON-LD schema had to leave the organization name blank to prevent the built-in schema from rendering — but this was fragile, as editors could fill it in later, causing duplicate schemas.

This PR adds a third "Disabled" option that explicitly opts out of the built-in entity schema while still allowing the Custom Schema textarea to be used for complete control over the JSON-LD markup.

<img width="976" height="851" alt="CleanShot 2026-06-12 at 11 33 22" src="https://github.com/user-attachments/assets/78430062-2d5a-489e-8983-3a038fad26d4" />

<p></p>

We _may_ look to add a more complicated "schema builder" in the future, but for now, we want to keep things simple + flexible so this is the easiest solution.

Closes #593