### PR TITLE
Handle trailing slashes when matching redirects

### DIFF
--- a/src/Redirects/HandleRedirects.php
+++ b/src/Redirects/HandleRedirects.php
@@ -57,10 +57,21 @@ class HandleRedirects
     private function findExactMatch(string $path, string $siteHandle): ?Redirect
     {
         return RedirectFacade::query()
-            ->where('source', $path)
+            ->whereIn('source', $this->sourceVariations($path))
             ->where('site', $siteHandle)
             ->where('enabled', true)
             ->first();
+    }
+
+    private function sourceVariations(string $path): array
+    {
+        if ($path === '/') {
+            return ['/'];
+        }
+
+        $withoutTrailingSlash = rtrim($path, '/');
+
+        return [$withoutTrailingSlash, $withoutTrailingSlash.'/'];
     }
 
     private function findWildcardMatch(string $path, string $siteHandle): ?Redirect

--- a/tests/Redirects/HandleRedirectsTest.php
+++ b/tests/Redirects/HandleRedirectsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Redirects;
 
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Queue;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Collection;
@@ -48,6 +49,42 @@ class HandleRedirectsTest extends TestCase
             ->get('/old-url')
             ->assertRedirect('/new-url')
             ->assertStatus(302);
+    }
+
+    #[Test]
+    public function it_redirects_when_visiting_url_with_trailing_slash()
+    {
+        Facades\Redirect::make()
+            ->id('abc')
+            ->source('/old-url')
+            ->destination('/new-url')
+            ->responseCode(301)
+            ->enabled(true)
+            ->save();
+
+        // The test HTTP client strips trailing slashes before dispatching, so the
+        // request is handled directly through the kernel to preserve it.
+        $response = $this->app->handle(Request::create('/old-url/', 'GET'));
+
+        $this->assertEquals(301, $response->getStatusCode());
+        $this->assertEquals('/new-url', parse_url($response->headers->get('Location'), PHP_URL_PATH));
+    }
+
+    #[Test]
+    public function it_redirects_when_rule_has_trailing_slash_but_url_does_not()
+    {
+        Facades\Redirect::make()
+            ->id('abc')
+            ->source('/old-url/')
+            ->destination('/new-url')
+            ->responseCode(301)
+            ->enabled(true)
+            ->save();
+
+        $this
+            ->get('/old-url')
+            ->assertRedirect('/new-url')
+            ->assertStatus(301);
     }
 
     #[Test]


### PR DESCRIPTION
This pull request fixes an issue where a redirect rule for `/foo` would not be triggered when visiting the same URL with a trailing slash (`/foo/`).

This was happening because `HandleRedirects` looked up the incoming request path against stored redirect sources verbatim, so a request to `/foo/` (which keeps its trailing slash) never matched a rule stored as `/foo`.

This PR fixes it by matching the request path against both its trailing-slash and non-trailing-slash variants, so visiting `/foo/` finds a `/foo` rule and vice-versa. The root path (`/`) is left untouched.

Fixes #609