### PR TITLE
Only output `Organization`/`Person` JSON-LD schemas on the homepage

### DIFF
--- a/lang/en/fieldsets/defaults.php
+++ b/lang/en/fieldsets/defaults.php
@@ -26,7 +26,7 @@ return [
     'json_ld_section' => 'JSON-LD',
 
     'json_ld_entity_section' => 'Entity Information',
-    'json_ld_entity_section_instruct' => 'Basic details about the organization or person this site represents.',
+    'json_ld_entity_section_instruct' => 'Basic details about the organization or person this site represents. This schema is only output on the homepage, as [recommended by Google](https://developers.google.com/search/docs/appearance/structured-data/organization).',
     'json_ld_entity' => 'Entity',
     'json_ld_entity_instruct' => 'This helps search engines understand the structured data on your site and improves the likelihood of it appearing with rich search results.',
     'json_ld_organization_name' => 'Organization Name',
@@ -37,7 +37,7 @@ return [
     'json_ld_person_name_instruct' => 'The full name of the person this site represents.',
 
     'json_ld_custom_section' => 'Custom Schema',
-    'json_ld_custom_section_instruct' => 'Add custom JSON-LD schema that will be included on every page across your site.',
+    'json_ld_custom_section_instruct' => 'Add a custom JSON-LD schema that will be output on every page across your site.',
     'json_ld_schema' => 'Schema',
     'json_ld_schema_instruct' => 'Paste your custom schema objects here (`LocalBusiness`, `SoftwareApplication`, etc). You can use Antlers to output data from the item. Will be wrapped in the appropriate script tag.',
 

--- a/lang/en/fieldsets/defaults.php
+++ b/lang/en/fieldsets/defaults.php
@@ -39,7 +39,7 @@ return [
     'json_ld_custom_section' => 'Custom Schema',
     'json_ld_custom_section_instruct' => 'Add a custom JSON-LD schema that will be output on every page across your site.',
     'json_ld_schema' => 'Schema',
-    'json_ld_schema_instruct' => 'Paste your custom schema objects here (`LocalBusiness`, `SoftwareApplication`, etc). You can use Antlers to output data from the item. Will be wrapped in the appropriate script tag.',
+    'json_ld_schema_instruct' => 'Paste your custom schema objects here (`WebSite`, `SiteNavigationElement`, etc). Will be wrapped in the appropriate script tag.',
 
     'json_ld_breadcrumbs_section' => 'Breadcrumbs',
     'json_ld_breadcrumbs' => 'Breadcrumbs',

--- a/src/Cascade.php
+++ b/src/Cascade.php
@@ -171,6 +171,18 @@ class Cascade
         return Site::current()?->absoluteUrl() ?? URL::makeAbsolute('/');
     }
 
+    protected function isHomePage(): bool
+    {
+        if (! method_exists($this->model, 'absoluteUrl')) {
+            return false;
+        }
+
+        $home = Str::removeRight((string) $this->site()->absoluteUrl(), '/');
+        $current = Str::removeRight((string) $this->model->absoluteUrl(), '/');
+
+        return $current !== '' && $current === $home;
+    }
+
     public function canonicalUrl()
     {
         $url = URL::tidy(Str::trim($this->explicitUrl ?? $this->data->get('canonical_url')));
@@ -619,7 +631,7 @@ class Cascade
         $jsonLdOrganizationLogo = $this->data->get('json_ld_organization_logo');
         $jsonLdPersonName = (string) $this->data->get('json_ld_person_name');
 
-        if ($jsonLdEntity === 'organization' && $jsonLdOrganizationName) {
+        if ($this->isHomePage() && $jsonLdEntity === 'organization' && $jsonLdOrganizationName) {
             if ($jsonLdOrganizationLogo && ! $jsonLdOrganizationLogo instanceof Value) {
                 $jsonLdOrganizationLogo = Asset::find($jsonLdOrganizationLogo);
             }
@@ -634,7 +646,7 @@ class Cascade
             ]), JSON_UNESCAPED_SLASHES));
         }
 
-        if ($jsonLdEntity === 'person' && $jsonLdPersonName) {
+        if ($this->isHomePage() && $jsonLdEntity === 'person' && $jsonLdPersonName) {
             $snippets->push(json_encode([
                 '@context' => 'https://schema.org',
                 '@type' => 'Person',

--- a/tests/CascadeTest.php
+++ b/tests/CascadeTest.php
@@ -443,6 +443,58 @@ class CascadeTest extends TestCase
     }
 
     #[Test]
+    public function it_only_outputs_organization_schema_on_the_homepage()
+    {
+        $siteDefaults = SiteDefaults::in('default')->set([
+            'json_ld_entity' => 'organization',
+            'json_ld_organization_name' => 'Cool Runnings Ltd',
+        ]);
+
+        $home = (new Cascade)
+            ->with($siteDefaults->all())
+            ->withCurrent(Entry::findByUri('/'))
+            ->get();
+
+        $this->assertContains(
+            '{"@context":"https://schema.org","@type":"Organization","name":"Cool Runnings Ltd","@id":"http://cool-runnings.com#organization","url":"http://cool-runnings.com"}',
+            $home['json_ld']->all()
+        );
+
+        $about = (new Cascade)
+            ->with($siteDefaults->all())
+            ->withCurrent(Entry::findByUri('/about'))
+            ->get();
+
+        $this->assertEmpty($about['json_ld']->all());
+    }
+
+    #[Test]
+    public function it_only_outputs_person_schema_on_the_homepage()
+    {
+        $siteDefaults = SiteDefaults::in('default')->set([
+            'json_ld_entity' => 'person',
+            'json_ld_person_name' => 'Derice Bannock',
+        ]);
+
+        $home = (new Cascade)
+            ->with($siteDefaults->all())
+            ->withCurrent(Entry::findByUri('/'))
+            ->get();
+
+        $this->assertContains(
+            '{"@context":"https://schema.org","@type":"Person","name":"Derice Bannock","@id":"http://cool-runnings.com#person","url":"http://cool-runnings.com"}',
+            $home['json_ld']->all()
+        );
+
+        $about = (new Cascade)
+            ->with($siteDefaults->all())
+            ->withCurrent(Entry::findByUri('/about'))
+            ->get();
+
+        $this->assertEmpty($about['json_ld']->all());
+    }
+
+    #[Test]
     public function it_parses_antlers_in_json_ld_schema_values()
     {
         $siteDefaults = SiteDefaults::in('default')->set([

--- a/tests/GraphQLTest.php
+++ b/tests/GraphQLTest.php
@@ -375,7 +375,7 @@ GQL;
 
         $query = <<<'GQL'
 {
-    entry(slug: "nectar") {
+    entry(slug: "home") {
         seo {
             json_ld
         }

--- a/tests/Localized/CascadeTest.php
+++ b/tests/Localized/CascadeTest.php
@@ -90,4 +90,33 @@ class CascadeTest extends LocalizedTestCase
         $this->assertEquals('About', $lastItem['name']);
         $this->assertEquals('http://cool-runnings.com/fr/about', $lastItem['item']);
     }
+
+    #[Test]
+    public function it_only_outputs_organization_schema_on_each_sites_homepage()
+    {
+        $siteDefaults = SiteDefaults::in('french')->set([
+            'json_ld_entity' => 'organization',
+            'json_ld_organization_name' => 'Cool Runnings Ltd',
+        ]);
+
+        $this->get('http://cool-runnings.com/fr');
+
+        $home = (new Cascade)
+            ->with($siteDefaults->all())
+            ->get();
+
+        $this->assertContains(
+            '{"@context":"https://schema.org","@type":"Organization","name":"Cool Runnings Ltd","@id":"http://cool-runnings.com/fr#organization","url":"http://cool-runnings.com/fr"}',
+            $home['json_ld']->all()
+        );
+
+        $this->get('http://cool-runnings.com/fr/about');
+
+        $about = (new Cascade)
+            ->with($siteDefaults->all())
+            ->withCurrent(Entry::findByUri('/about', 'french')->entry())
+            ->get();
+
+        $this->assertEmpty($about['json_ld']->all());
+    }
 }


### PR DESCRIPTION
While not mandatory, [Google recommends](https://developers.google.com/search/docs/appearance/structured-data/organization#technical-guidelines) that the `Organization` schema is only output on the homepage, or another page specifically about the organization, like an "About" page:

> We recommend placing this information on your home page, or a single page that describes your organization, for example the about us page. You don't need to include it on every page of your site.

This PR makes it so the `Organization` and `Person` schemas are only output on the homepage, rather than every page. 

If you've chosen to disable SEO Pro's entity information, you'll probably want to put your custom JSON-LD schema in the relevant entry directly (eg. your homepage), rather than in the "JSON-LD Schema" textbox in site defaults, as that's designed to be output on every page.

<img width="1047" height="307" alt="CleanShot 2026-06-19 at 10 49 58" src="https://github.com/user-attachments/assets/7b9c5a51-37f3-4231-acd4-a5b36806857c" />

Related: #605