### PR TITLE
Scope duplicate title & description checks to the current site

### DIFF
--- a/src/Reporting/Chunk.php
+++ b/src/Reporting/Chunk.php
@@ -86,6 +86,8 @@ class Chunk
             ->withCurrent($content)
             ->get();
 
+        $data['site'] = $content->locale();
+
         return new Page($content->id(), $data, $this->report);
     }
 }

--- a/src/Reporting/Page.php
+++ b/src/Reporting/Page.php
@@ -127,6 +127,11 @@ class Page implements Arrayable
         return $this->get('canonical_url');
     }
 
+    public function site()
+    {
+        return $this->get('site');
+    }
+
     public function id()
     {
         return $this->id;

--- a/src/Reporting/Rules/UniqueMetaDescription.php
+++ b/src/Reporting/Rules/UniqueMetaDescription.php
@@ -57,10 +57,14 @@ class UniqueMetaDescription extends Rule
 
     protected function groupAllPagesByDescription()
     {
-        return Blink::once('seo-pro-report-'.$this->report->id().'-page-descriptions-grouped', function () {
-            return $this->page->report()->pages()->mapToGroups(function ($page) {
-                return [$page->get('description') => $page->id()];
-            });
+        $site = $this->page->site();
+
+        return Blink::once('seo-pro-report-'.$this->report->id().'-page-descriptions-grouped-'.$site, function () use ($site) {
+            return $this->page->report()->pages()
+                ->filter(fn ($page) => $page->site() === $site)
+                ->mapToGroups(function ($page) {
+                    return [$page->get('description') => $page->id()];
+                });
         });
     }
 

--- a/src/Reporting/Rules/UniqueTitleTag.php
+++ b/src/Reporting/Rules/UniqueTitleTag.php
@@ -57,10 +57,14 @@ class UniqueTitleTag extends Rule
 
     protected function groupAllPagesByTitle()
     {
-        return Blink::once('seo-pro-report-'.$this->report->id().'-page-titles-grouped', function () {
-            return $this->page->report()->pages()->mapToGroups(function ($page) {
-                return [$page->get('title') => $page->id()];
-            });
+        $site = $this->page->site();
+
+        return Blink::once('seo-pro-report-'.$this->report->id().'-page-titles-grouped-'.$site, function () use ($site) {
+            return $this->page->report()->pages()
+                ->filter(fn ($page) => $page->site() === $site)
+                ->mapToGroups(function ($page) {
+                    return [$page->get('title') => $page->id()];
+                });
         });
     }
 

--- a/tests/Localized/ReportTest.php
+++ b/tests/Localized/ReportTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Tests\Localized;
+
+use Illuminate\Support\Carbon;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Entry;
+use Statamic\Facades\Term;
+use Statamic\Facades\YAML;
+use Statamic\SeoPro\Reporting\Report;
+use Statamic\Support\Str;
+
+class ReportTest extends LocalizedTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Entry::all()->filter(fn ($entry) => $entry->hasOrigin())->each->delete();
+        Entry::all()->each->delete();
+        Term::all()->each->delete();
+
+        if ($this->files->exists($path = $this->reportsPath())) {
+            $this->files->deleteDirectory($path);
+        }
+    }
+
+    /**
+     * @see https://github.com/statamic/seo-pro/issues/213
+     */
+    #[Test]
+    public function it_does_not_flag_duplicate_titles_and_descriptions_across_sites()
+    {
+        $this->makeArticle('default', 'one', 'Shared Title', 'Shared Description');
+        $this->makeArticle('french', 'two', 'Shared Title', 'Shared Description');
+
+        $this->assertEqualsIgnoringLineEndings(0, $this->getReportResult('UniqueTitleTag'));
+        $this->assertEqualsIgnoringLineEndings(0, $this->getReportResult('UniqueMetaDescription'));
+    }
+
+    /**
+     * @see https://github.com/statamic/seo-pro/issues/213
+     */
+    #[Test]
+    public function it_still_flags_duplicate_titles_and_descriptions_within_the_same_site()
+    {
+        $this->makeArticle('default', 'one', 'Shared Title', 'Shared Description');
+        $this->makeArticle('default', 'two', 'Shared Title', 'Shared Description');
+        $this->makeArticle('french', 'three', 'Shared Title', 'Shared Description');
+
+        $this->assertEqualsIgnoringLineEndings(2, $this->getReportResult('UniqueTitleTag'));
+        $this->assertEqualsIgnoringLineEndings(2, $this->getReportResult('UniqueMetaDescription'));
+    }
+
+    protected function makeArticle($site, $slug, $title, $description)
+    {
+        Entry::make()
+            ->collection('articles')
+            ->blueprint('articles')
+            ->locale($site)
+            ->slug($slug)
+            ->date('2024-01-01')
+            ->set('title', $title)
+            ->set('seo', ['title' => $title, 'description' => $description])
+            ->save();
+
+        return $this;
+    }
+
+    protected function reportsPath($path = null)
+    {
+        if ($path) {
+            $path = Str::ensureLeft($path, '/');
+        }
+
+        return storage_path('statamic/seopro/reports').$path;
+    }
+
+    protected function getReportResult($key)
+    {
+        Carbon::setTestNow(now());
+
+        Report::create()->save()->generate();
+
+        return YAML::file($this->reportsPath('1/report.yaml'))->parse()['results'][$key];
+    }
+
+    public static function assertEqualsIgnoringLineEndings($needle, $haystack, $message = ''): void
+    {
+        parent::assertEquals(
+            is_string($needle) ? static::normalizeMultilineString($needle) : $needle,
+            is_string($haystack) ? static::normalizeMultilineString($haystack) : $haystack,
+            $message
+        );
+    }
+}

--- a/tests/Localized/ReportTest.php
+++ b/tests/Localized/ReportTest.php
@@ -52,7 +52,7 @@ class ReportTest extends LocalizedTestCase
         $this->assertEqualsIgnoringLineEndings(2, $this->getReportResult('UniqueMetaDescription'));
     }
 
-    protected function makeArticle($site, $slug, $title, $description)
+    private function makeArticle($site, $slug, $title, $description)
     {
         Entry::make()
             ->collection('articles')
@@ -67,7 +67,7 @@ class ReportTest extends LocalizedTestCase
         return $this;
     }
 
-    protected function reportsPath($path = null)
+    private function reportsPath($path = null)
     {
         if ($path) {
             $path = Str::ensureLeft($path, '/');
@@ -76,7 +76,7 @@ class ReportTest extends LocalizedTestCase
         return storage_path('statamic/seopro/reports').$path;
     }
 
-    protected function getReportResult($key)
+    private function getReportResult($key)
     {
         Carbon::setTestNow(now());
 

--- a/tests/Localized/ReportTest.php
+++ b/tests/Localized/ReportTest.php
@@ -84,13 +84,4 @@ class ReportTest extends LocalizedTestCase
 
         return YAML::file($this->reportsPath('1/report.yaml'))->parse()['results'][$key];
     }
-
-    public static function assertEqualsIgnoringLineEndings($needle, $haystack, $message = ''): void
-    {
-        parent::assertEquals(
-            is_string($needle) ? static::normalizeMultilineString($needle) : $needle,
-            is_string($haystack) ? static::normalizeMultilineString($haystack) : $haystack,
-            $message
-        );
-    }
 }

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -510,18 +510,6 @@ EXPECTED;
 
         return YAML::file($this->reportsPath('1/report.yaml'))->parse()['results'][$key];
     }
-
-    /**
-     * Normalize line endings before performing assertion in windows.
-     */
-    public static function assertEqualsIgnoringLineEndings($needle, $haystack, $message = ''): void
-    {
-        parent::assertEquals(
-            is_string($needle) ? static::normalizeMultilineString($needle) : $needle,
-            is_string($haystack) ? static::normalizeMultilineString($haystack) : $haystack,
-            $message
-        );
-    }
 }
 
 class TestChunk extends Chunk

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -466,7 +466,7 @@ EXPECTED;
         ], $this->getReportResult('IdealMetaDescriptionLength'));
     }
 
-    public function reportsPath($path = null)
+    private function reportsPath($path = null)
     {
         if ($path) {
             $path = Str::ensureLeft($path, '/');
@@ -475,7 +475,7 @@ EXPECTED;
         return storage_path('statamic/seopro/reports').$path;
     }
 
-    protected function generateEntries($count)
+    private function generateEntries($count)
     {
         collect(range(1, $count))->each(function ($i) {
             Entry::make()
@@ -489,7 +489,7 @@ EXPECTED;
         return $this;
     }
 
-    protected function generateTerms($count)
+    private function generateTerms($count)
     {
         collect(range(1, $count))->each(function ($i) {
             Term::make()
@@ -502,7 +502,7 @@ EXPECTED;
         return $this;
     }
 
-    protected function getReportResult($key)
+    private function getReportResult($key)
     {
         Carbon::setTestNow($now = now());
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -138,6 +138,18 @@ abstract class TestCase extends AddonTestCase
         );
     }
 
+    /**
+     * Normalize line endings before performing assertion in windows.
+     */
+    public static function assertEqualsIgnoringLineEndings(mixed $expected, mixed $actual, string $message = ''): void
+    {
+        parent::assertEquals(
+            is_string($expected) ? static::normalizeMultilineString($expected) : $expected,
+            is_string($actual) ? static::normalizeMultilineString($actual) : $actual,
+            $message
+        );
+    }
+
     protected function assertArrayHasKeys(array $keys, array|\ArrayAccess $array): void
     {
         foreach ($keys as $key) {


### PR DESCRIPTION
This pull request fixes an issue where SEO Pro would flag duplicate titles and descriptions across sites in a multi-site.

This was happening because the `UniqueTitleTag` and `UniqueMetaDescription` rules compared each page's title/description against every page in the report, regardless of which site it belonged to.

Since localized entries inherit their origin's title and description, the same content served on different sites (e.g. `/` and `/ga/`) collided and was reported as duplicate. This is a false positive, as these are hreflang alternates that Google treats as the same page rather than duplicates.

This PR fixes it by scoping the uniqueness comparison to pages on the same site. 

Fixes #213