### PR TITLE
Retain current tab hash in URL when switching localization

### DIFF
--- a/resources/js/pages/site-defaults/Edit.vue
+++ b/resources/js/pages/site-defaults/Edit.vue
@@ -92,7 +92,7 @@ const confirmSwitchLocalization = () => {
 const switchToLocalization = (localization) => {
 	localizing.value = localization.handle;
 
-	window.history.replaceState({}, '', localization.url);
+	window.history.replaceState({}, '', localization.url + window.location.hash);
 
 	$axios.get(localization.url).then((response) => {
 		const data = response.data;


### PR DESCRIPTION
When you navigate between tabs in the site defaults publish form, the tab handle is used as a URL hash (eg. `/edit#json-ld`). This  means you'll stay on the same tab if you refresh the page.

However, if you switch localization, the hash disappears and you end up with just the `site` query parameter. Refreshing the page will take you back to the first tab.

This PR ensures the hash is retained when switching localizations.