### PR TITLE
Fix PostgreSQL not-null violation when adding redirects

### DIFF
--- a/src/Redirects/Eloquent/ErrorRepository.php
+++ b/src/Redirects/Eloquent/ErrorRepository.php
@@ -49,7 +49,10 @@ class ErrorRepository extends StacheRepository implements RepositoryContract
     {
         $model = ErrorModel::find($error->id()) ?? new ErrorModel;
 
-        $model->id = $error->id();
+        if (! is_null($error->id())) {
+            $model->id = $error->id();
+        }
+
         $model->site = $error->site();
         $model->url = $error->url();
         $model->hits = $error->hits();

--- a/src/Redirects/Eloquent/RedirectRepository.php
+++ b/src/Redirects/Eloquent/RedirectRepository.php
@@ -52,7 +52,10 @@ class RedirectRepository extends StacheRepository implements RepositoryContract
     {
         $model = RedirectModel::find($redirect->id()) ?? new RedirectModel;
 
-        $model->id = $redirect->id();
+        if (! is_null($redirect->id())) {
+            $model->id = $redirect->id();
+        }
+
         $model->site = $redirect->site();
         $model->source = $redirect->source();
         $model->destination = $redirect->destination();

--- a/tests/Redirects/Eloquent/ErrorRepositoryTest.php
+++ b/tests/Redirects/Eloquent/ErrorRepositoryTest.php
@@ -89,6 +89,20 @@ class ErrorRepositoryTest extends TestCase
     }
 
     #[Test]
+    public function it_does_not_set_a_null_id_when_saving_a_new_error()
+    {
+        $error = Facades\Error::make()
+            ->url('/missing-page')
+            ->hits(1)
+            ->lastHitAt('2026-04-21 12:00:00');
+
+        $method = new \ReflectionMethod($this->repo, 'toModel');
+        $model = $method->invoke($this->repo, $error);
+
+        $this->assertArrayNotHasKey('id', $model->getAttributes());
+    }
+
+    #[Test]
     public function it_sets_default_site_when_saving_without_one()
     {
         $error = Facades\Error::make()

--- a/tests/Redirects/Eloquent/RedirectRepositoryTest.php
+++ b/tests/Redirects/Eloquent/RedirectRepositoryTest.php
@@ -97,6 +97,21 @@ class RedirectRepositoryTest extends TestCase
     }
 
     #[Test]
+    public function it_does_not_set_a_null_id_when_saving_a_new_redirect()
+    {
+        $redirect = Facades\Redirect::make()
+            ->source('/old-url')
+            ->destination('/new-url')
+            ->responseCode(302)
+            ->enabled(true);
+
+        $method = new \ReflectionMethod($this->repo, 'toModel');
+        $model = $method->invoke($this->repo, $redirect);
+
+        $this->assertArrayNotHasKey('id', $model->getAttributes());
+    }
+
+    #[Test]
     public function it_sets_default_site_when_saving_without_one()
     {
         $redirect = Facades\Redirect::make()


### PR DESCRIPTION
This pull request fixes an issue where creating a new redirect (or error) with the database driver fails on PostgreSQL with `SQLSTATE 23502`.

This was happening because `toModel()` unconditionally assigned `$model->id = $redirect->id()`. For new records, that ID is `null`, so the INSERT explicitly sent `id = null` rather than omitting it. SQLite tolerates this and autoincrements anyway, but PostgreSQL rejects it as a not-null violation.

This PR fixes it by only assigning the model's ID when it isn't null, letting the database generate it on insert. The same fix has been applied to the `ErrorRepository`, which had the identical bug.

Fixes #618

🤖 Generated with [Claude Code](https://claude.com/claude-code)