### PR TITLE
Fix Site Defaults save failing with "axios is not defined"

### DIFF
--- a/resources/js/components/site-defaults/ConfigureModal.vue
+++ b/resources/js/components/site-defaults/ConfigureModal.vue
@@ -23,7 +23,7 @@ const save = () => {
 	busy.value = true;
 	error.value = null;
 
-	axios.patch(props.route, { sites: sites.value })
+	$axios.patch(props.route, { sites: sites.value })
 		.then(() => {
 			Statamic.$toast.success(__('Saved'));
 			emit('saved');


### PR DESCRIPTION
This pull request fixes an issue where saving the Site Defaults configuration in the Control Panel failed with `ReferenceError: axios is not defined`.

This was happening because the save action in `ConfigureModal.vue` referenced the bare global `axios`, which isn't defined in the component's scope.

This PR fixes it by using the `$axios` instance already destructured from the app's global properties, matching how the GET request in the same component works.