### PR TITLE
Improve Site Defaults performance with many sites

### DIFF
--- a/src/SiteDefaults/LocalizedSiteDefaults.php
+++ b/src/SiteDefaults/LocalizedSiteDefaults.php
@@ -4,6 +4,7 @@ namespace Statamic\SeoPro\SiteDefaults;
 
 use Illuminate\Support\Collection;
 use Statamic\Data\HasOrigin;
+use Statamic\Facades\Blink;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\Site;
 use Statamic\SeoPro\Events\SiteDefaultsSaved;
@@ -98,23 +99,25 @@ class LocalizedSiteDefaults
 
     public function augmented(): array
     {
-        $contentValues = Blueprint::make()
-            ->setContents(['tabs' => ['main' => ['sections' => Fields::new()->getConfig()]]])
-            ->fields()
-            ->addValues($this->values()->all())
-            ->augment()
-            ->values();
+        return Blink::once("seo-pro::site-defaults.augmented.{$this->locale}", function () {
+            $contentValues = Blueprint::make()
+                ->setContents(['tabs' => ['main' => ['sections' => Fields::new()->getConfig()]]])
+                ->fields()
+                ->addValues($this->values()->all())
+                ->augment()
+                ->values();
 
-        $siteDefaultValues = $this->blueprint()
-            ->fields()
-            ->addValues($this->values()->all())
-            ->augment()
-            ->values();
+            $siteDefaultValues = $this->blueprint()
+                ->fields()
+                ->addValues($this->values()->all())
+                ->augment()
+                ->values();
 
-        return $siteDefaultValues
-            ->merge($contentValues)
-            ->only($this->keys()->all())
-            ->all();
+            return $siteDefaultValues
+                ->merge($contentValues)
+                ->only($this->keys()->all())
+                ->all();
+        });
     }
 
     public function editUrl(): string

--- a/src/SiteDefaults/SiteDefaults.php
+++ b/src/SiteDefaults/SiteDefaults.php
@@ -32,15 +32,18 @@ class SiteDefaults
     public static function origins($origins = null): Collection|bool
     {
         if (func_num_args() === 0) {
-            return Site::all()
-                ->mapWithKeys(fn ($site) => [$site->handle() => null])
-                ->merge(Addon::get('statamic/seo-pro')->settings()->get('site_defaults_sites', []))
-                ->map(fn ($origin) => empty($origin) ? null : $origin);
+            return Blink::once('seo-pro::site-defaults-origins', function () {
+                return Site::all()
+                    ->mapWithKeys(fn ($site) => [$site->handle() => null])
+                    ->merge(Addon::get('statamic/seo-pro')->settings()->get('site_defaults_sites', []))
+                    ->map(fn ($origin) => empty($origin) ? null : $origin);
+            });
         }
 
         Addon::get('statamic/seo-pro')->settings()->set('site_defaults_sites', $origins)->save();
 
         Blink::forget('seo-pro::site-defaults');
+        Blink::forget('seo-pro::site-defaults-origins');
 
         return true;
     }
@@ -67,6 +70,7 @@ class SiteDefaults
         Addon::get('statamic/seo-pro')->settings()->set('site_defaults', $data)->save();
 
         Blink::forget('seo-pro::site-defaults');
+        Blink::forget("seo-pro::site-defaults.augmented.{$localized->locale()}");
 
         return true;
     }


### PR DESCRIPTION
This pull request fixes performance issues with Site Defaults that get noticeably worse as the number of configured sites grows — the Site Defaults page in the Control Panel could take 30 seconds or more to load, and there was a slowdown on the front-end during metadata retrieval.

This was happening because `SiteDefaults::origins()` rebuilt the addon settings from disk on every call (a YAML parse plus running Antlers over every stored value), and it's called once per site while building the page, so the work scaled roughly with the square of the site count. `LocalizedSiteDefaults::augmented()` had a similar issue, running two full blueprint augmentation passes on every call with no memoization.

This PR fixes it by memoizing both with `Blink::once` — matching how `SiteDefaults::get()` and the section defaults equivalent are already cached — and invalidating the caches when defaults are saved.