### PR TITLE
Use `application/ld+json` mode for JSON-LD code fields

### DIFF
--- a/src/Fields.php
+++ b/src/Fields.php
@@ -171,7 +171,7 @@ class Fields
                             'full_width_setting' => true,
                             'field' => [
                                 'type' => 'code',
-                                'mode' => 'javascript',
+                                'mode' => 'application/ld+json',
                                 'mode_selectable' => false,
                                 'show_mode_label' => false,
                                 'validate' => [

--- a/src/SiteDefaults/Blueprint.php
+++ b/src/SiteDefaults/Blueprint.php
@@ -159,7 +159,7 @@ class Blueprint
                                         'display' => __('seo-pro::fieldsets/defaults.json_ld_schema'),
                                         'instructions' => __('seo-pro::fieldsets/defaults.json_ld_schema_instruct'),
                                         'type' => 'code',
-                                        'mode' => 'javascript',
+                                        'mode' => 'application/ld+json',
                                         'mode_selectable' => false,
                                         'show_mode_label' => false,
                                         'localizable' => true,


### PR DESCRIPTION
This pull request adopts the `application/ld+json` mode for the Code Fieldtype introduced in https://github.com/statamic/cms/pull/14904.