### PR TITLE
Fix Control Panel crash when SEO fields contain invalid Antlers

### DIFF
--- a/src/Cascade.php
+++ b/src/Cascade.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\SeoPro;
 
+use Exception;
 use Illuminate\Support\Collection;
 use Statamic\Contracts\Query\Builder;
 use Statamic\Facades\Antlers;
@@ -17,7 +18,6 @@ use Statamic\Fieldtypes\Bard;
 use Statamic\Statamic;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
-use Statamic\View\Antlers\Language\Exceptions\RuntimeException;
 use Statamic\View\Cascade as ViewCascade;
 
 class Cascade
@@ -505,7 +505,7 @@ class Cascade
                 app(ViewCascade::class)->toArray(),
                 $this->current ?? [],
             ));
-        } catch (RuntimeException $e) {
+        } catch (Exception $e) {
             return $item;
         }
     }
@@ -526,7 +526,7 @@ class Cascade
                 $this->current ?? [],
                 ['seo' => $this->data->all()],
             ));
-        } catch (RuntimeException $e) {
+        } catch (Exception $e) {
             return $item;
         }
     }

--- a/src/Cascade.php
+++ b/src/Cascade.php
@@ -506,6 +506,8 @@ class Cascade
                 $this->current ?? [],
             ));
         } catch (Exception $e) {
+            report($e);
+
             return $item;
         }
     }
@@ -527,6 +529,8 @@ class Cascade
                 ['seo' => $this->data->all()],
             ));
         } catch (Exception $e) {
+            report($e);
+
             return $item;
         }
     }

--- a/tests/CascadeTest.php
+++ b/tests/CascadeTest.php
@@ -153,6 +153,35 @@ class CascadeTest extends TestCase
         $this->assertEquals('[My Site] [] [default]', $data['title']);
     }
 
+    #[Test]
+    public function it_returns_the_raw_value_when_a_value_contains_invalid_antlers()
+    {
+        $entry = Entry::findByUri('/about')->entry();
+
+        $data = (new Cascade)
+            ->withSiteDefaults(SiteDefaults::in('default')->all())
+            ->with([
+                'description' => '{{ collection from="locations" }}',
+            ])
+            ->withCurrent($entry)
+            ->get();
+
+        $this->assertEquals('{{ collection from="locations" }}', $data['description']);
+    }
+
+    #[Test]
+    public function it_returns_the_raw_schema_when_json_ld_schema_contains_invalid_antlers()
+    {
+        $data = (new Cascade)
+            ->with([
+                'title' => 'Home',
+                'json_ld_schema' => '{{ collection from="locations" }}',
+            ])
+            ->get();
+
+        $this->assertEquals(['{{ collection from="locations" }}'], $data['json_ld']->all());
+    }
+
     public static function phpInAntlersProvider()
     {
         return [


### PR DESCRIPTION
When an SEO field value contains Antlers that fails to parse, for example `{{ collection from="locations" }}` in the JSON-LD schema field (`from` gets treated as a modifier), the resulting `ModifierNotFoundException` escapes the Cascade. Since the Cascade runs during fieldtype preload, this 500s the entry save and, because the invalid value has already been persisted at that point, every subsequent visit to the entry's edit page too. The entry stays uneditable until the file is fixed by hand. Reported in statamic/seo-pro#632.

Both parse sites in the Cascade already had a fallback that returns the raw value, but it only caught the Antlers `RuntimeException`. Exceptions like `ModifierNotFoundException` extend the base `Exception` class and slipped through. This broadens the two catches so any parse failure degrades to the raw value, which is what the guard intended.

Note this also applies on the front end: an invalid schema is now emitted raw inside the JSON-LD script tag instead of throwing. Invalid JSON-LD, but consistent with the existing fallback and preferable to a 500.

Related: #629 touches the same field but has a different symptom.

Fixes statamic/seo-pro#632

🤖 Generated with [Claude Code](https://claude.com/claude-code)
