### PR TITLE
Fix publish form freezing when the seo field has a condition

### DIFF
--- a/resources/js/cp.js
+++ b/resources/js/cp.js
@@ -36,4 +36,14 @@ Statamic.booting(() => {
 
     Statamic.$components.register('seo-pro-widget', SeoProWidget);
     Statamic.$components.register('seo-pro-recent-errors-widget', RecentErrorsWidget);
+
+    Statamic.$conditions.add('showSeoProPreviews', ({ values, container }) => {
+        if (container?.hiddenFields?.value?.seo?.hidden) {
+            return false;
+        }
+
+        const seo = (container?.values?.value ?? values)?.seo;
+
+        return seo?.enabled !== false;
+    });
 });

--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -79,7 +79,7 @@ class Blueprint
                 'display' => 'SEO Previews',
                 'localizable' => false,
                 'hide_display' => true,
-                'unless' => ['seo.enabled' => 'equals false'],
+                'if' => 'custom showSeoProPreviews',
             ],
             tab: 'SEO Previews',
             prepend: true


### PR DESCRIPTION
This pull request fixes an issue where adding a condition to the `seo_pro` field would freeze the publish form, leaving the page stuck loading forever.

This was happening because the `seo_previews` field's baked-in `unless: seo.enabled equals false` condition reads another field's value. The publish form evaluates field conditions in two places: once per-field against all values, and once per-tab against only the visible values, where a conditionally-hidden field's values are omitted. When a condition hides the `seo` field, the two evaluations disagree about whether `seo_previews` should be shown and endlessly overwrite each other's hidden state, sending the publish form into an infinite loop.

This PR fixes it by replacing the baked-in condition with a custom condition, which resolves the `seo` field's values from the publish container so every evaluation sees the same thing. It also hides the previews field whenever the `seo` field itself is hidden, rather than showing previews alongside a hidden SEO Meta tab.

Fixes #627