### PR TITLE
Prepend site URL when testing redirects

### DIFF
--- a/resources/js/components/redirects/PublishForm.vue
+++ b/resources/js/components/redirects/PublishForm.vue
@@ -83,7 +83,7 @@ const testRedirect = () => {
 		return `wildcard${wildcardIndex}`;
 	});
 
-	window.open(url, '_blank');
+	window.open(props.initialMeta.source?.site_url + url, '_blank');
 };
 </script>
 


### PR DESCRIPTION
This pull request fixes an issue where the "Test Redirect" button opened the wrong URL on multisites where a site lives under a URL prefix (eg. an `en` site at `example.com/en/`).

This was happening because redirect sources are stored as site-relative paths, but the button opened the source relative to the domain root — so testing `/gallery/old-slug` on the `en` site opened `example.com/gallery/old-slug`, which hits the default site and 404s, making a working redirect look broken.

This PR fixes it by prepending the site's base URL (the same one shown before the source input) when opening the test URL.

Fixes #628