### PR TITLE
Noindex error pages instead of emitting canonical and hreflang meta

### DIFF
--- a/src/Cascade.php
+++ b/src/Cascade.php
@@ -102,8 +102,14 @@ class Cascade
             return $this->getForSitemap();
         }
 
-        if (Arr::get($this->data, 'response_code') === 404) {
+        $responseCode = Arr::get($this->data, 'response_code', 200);
+
+        if ($responseCode === 404) {
             $this->current['title'] = '404 Page Not Found';
+        }
+
+        if ($responseCode >= 400) {
+            $this->data->put('robots_indexing', 'noindex');
         }
 
         $this->data = $this->data->map(function ($item, $key) {

--- a/tests/CascadeTest.php
+++ b/tests/CascadeTest.php
@@ -288,6 +288,20 @@ class CascadeTest extends TestCase
     }
 
     #[Test]
+    public function it_noindexes_error_pages()
+    {
+        $data = (new Cascade)
+            ->withSiteDefaults(SiteDefaults::in('default')->all())
+            ->with([
+                'response_code' => 404,
+            ])
+            ->get();
+
+        $this->assertContains('noindex', $data['robots']);
+        $this->assertEquals('noindex', $data['robots_indexing']);
+    }
+
+    #[Test]
     public function it_generates_next_and_prev_urls_off_tag_paginator_from_cms_core()
     {
         $entry = Entry::findByUri($uri = '/about')->entry();

--- a/tests/Localized/MetaTagTest.php
+++ b/tests/Localized/MetaTagTest.php
@@ -338,4 +338,18 @@ EOT;
         $this->assertStringContainsStringIgnoringLineEndings("<h1>{$viewType}</h1>", $content);
         $this->assertStringContainsStringIgnoringLineEndings('<title>Corse Fantastiche | Home</title>', $content);
     }
+
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
+    public function it_doesnt_generate_multisite_meta_for_404_pages($viewType)
+    {
+        $this->prepareViews($viewType);
+
+        $content = $this->get('/non-existent-page')->content();
+
+        $this->assertStringContainsStringIgnoringLineEndings('<h2>404!</h2>', $content);
+        $this->assertStringContainsStringIgnoringLineEndings('<meta name="robots" content="noindex" />', $content);
+        $this->assertStringNotContainsString('rel="canonical"', $content);
+        $this->assertStringNotContainsString('hreflang', $content);
+    }
 }

--- a/tests/MetaTagTest.php
+++ b/tests/MetaTagTest.php
@@ -732,6 +732,37 @@ EOT;
 
     #[Test]
     #[DataProvider('viewScenarioProvider')]
+    public function it_noindexes_404_pages_and_omits_canonical_meta($viewType)
+    {
+        $this->prepareViews($viewType);
+
+        $content = $this->get('/non-existent-page')->content();
+
+        $this->assertStringContainsStringIgnoringLineEndings('<h2>404!</h2>', $content);
+        $this->assertStringContainsStringIgnoringLineEndings('<meta name="robots" content="noindex" />', $content);
+        $this->assertStringNotContainsString('rel="canonical"', $content);
+    }
+
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
+    public function it_noindexes_404_pages_even_when_site_defaults_allow_indexing($viewType)
+    {
+        $this
+            ->prepareViews($viewType)
+            ->setSeoInSiteDefaults([
+                'robots_indexing' => 'index',
+                'robots_following' => 'follow',
+            ]);
+
+        $content = $this->get('/non-existent-page')->content();
+
+        $this->assertStringContainsStringIgnoringLineEndings('<h2>404!</h2>', $content);
+        $this->assertStringContainsStringIgnoringLineEndings('<meta name="robots" content="noindex, follow" />', $content);
+        $this->assertStringNotContainsString('rel="canonical"', $content);
+    }
+
+    #[Test]
+    #[DataProvider('viewScenarioProvider')]
     public function it_hydrates_cascade_on_custom_routes_using_blade_directive($viewType)
     {
         if ($viewType === 'antlers') {


### PR DESCRIPTION
This pull request fixes an issue where error pages (eg. 404s) would include a self-referential `<link rel="canonical">` and a full set of `hreflang` alternates pointing to the non-existent request URL, along with an inconsistent `robots` meta tag across sites.

This was happening because when no entry resolves for the current URL, the cascade falls back to the request URL as the canonical URL, and `robots` was left to whatever the site defaults specified — so some sites advertised the failing URL as `index, follow` while others output no `robots` tag at all.

This PR fixes it by treating error responses as non-indexable: when the response code is 400 or above, `robots_indexing` is forced to `noindex`. Error pages now consistently output a `noindex` robots meta tag, and the canonical, home, prev/next, and `hreflang` links are omitted.

Fixes #633