### PR TITLE
Fix custom JSON-LD schema failing to save in Site Defaults

### DIFF
--- a/src/Fieldtypes/Rules/SourceFieldRule.php
+++ b/src/Fieldtypes/Rules/SourceFieldRule.php
@@ -23,7 +23,7 @@ class SourceFieldRule implements ValidationRule
         // Run any validation rules that might belong on the source field.
         if ($value['source'] === 'custom') {
             $data = [];
-            Arr::set($data, $attribute, $value['value']);
+            Arr::set($data, $attribute, $this->sourceField->fieldtype()->preProcessValidatable($value['value']));
 
             Validator::make($data, [$attribute => $this->sourceField->get('validate', [])])->validate();
         }

--- a/src/Fieldtypes/Rules/ValidJsonLd.php
+++ b/src/Fieldtypes/Rules/ValidJsonLd.php
@@ -10,7 +10,7 @@ class ValidJsonLd implements ValidationRule
 {
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        if (Str::startsWith($value['code'], '<script')) {
+        if ($value && Str::startsWith($value, '<script')) {
             $fail('seo-pro::validation.json_ld_omit_script_tags')->translate();
         }
     }


### PR DESCRIPTION
This pull request fixes an issue where saving a custom JSON-LD schema in Site Defaults blew up with `TypeError: Cannot access offset of type string on string`. The same field in Section Defaults saved fine.

This was happening because `Code::preProcessValidatable()` was added in statamic/cms v6.25.0, which unwraps `['code' => ..., 'mode' => ...]` down to the bare string before validation rules run. `json_ld_schema` is a top-level `code` field in Site Defaults, so `ValidJsonLd` started receiving a string and choked on `$value['code']`. In Section Defaults the field is nested inside `seo_pro_source`, where `SourceFieldRule` builds its own validator straight from the raw value and skips `preProcessValidatable()` entirely, so it carried on receiving an array.

Worth noting this means the bug tracks the Statamic version rather than the SEO Pro version, which is why downgrading SEO Pro didn't help.

This PR fixes it by running the nested value through `preProcessValidatable()` in `SourceFieldRule`, so source field rules see the same shape core hands to top-level fields, and by validating the string in `ValidJsonLd`. As a bonus, rules like `required` on a source field now behave the way they do in core — previously an empty `['code' => null, 'mode' => ...]` array read as non-empty.

Fixes #640
Caused by statamic/cms#14918