### PR TITLE
Add configurable cap on tracked 404 errors

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -317,6 +317,18 @@ You may customize the purge threshold in the config:
 ],
 ```
 
+On a public site, bots probing for unique URLs can create an unbounded number of errors between purges. To bound the total, set `max_errors` to a cap. When the purge runs and the number of errors exceeds the cap, the excess is evicted: errors that have never been hit go first, then those with the fewest hits, then those hit least recently. Frequently-hit 404s, the best redirect candidates, survive longest. The default of `0` disables the cap.
+
+```php
+// config/statamic/seo-pro.php
+
+'redirects' => [
+    'errors' => [
+        'max_errors' => 1000,
+    ],
+],
+```
+
 You may also run the command manually:
 
 ```

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -317,7 +317,7 @@ You may customize the purge threshold in the config:
 ],
 ```
 
-On a public site, bots probing for unique URLs can create an unbounded number of errors between purges. To bound the total, set `max_errors` to a cap. When the purge runs and the number of errors exceeds the cap, the excess is evicted: errors that have never been hit go first, then those with the fewest hits, then those hit least recently. Frequently-hit 404s, the best redirect candidates, survive longest. The default of `0` disables the cap.
+On a public site, bots probing for unique URLs can create an unbounded number of errors between purges. To bound the total, set `max_errors` to a cap. When the purge runs and the number of errors exceeds the cap, the excess is purged: errors that have never been hit go first, then those with the fewest hits, then those hit least recently. Frequently-hit 404s, the best redirect candidates, survive longest. The default of `0` disables the cap.
 
 ```php
 // config/statamic/seo-pro.php

--- a/config/seo-pro.php
+++ b/config/seo-pro.php
@@ -80,6 +80,7 @@ return [
             'driver' => 'file',
             'directory' => storage_path('statamic/seopro/errors'),
             'purge_after_days' => 30,
+            'max_errors' => 0,
         ],
     ],
 

--- a/src/Commands/PurgeErrorsCommand.php
+++ b/src/Commands/PurgeErrorsCommand.php
@@ -24,7 +24,7 @@ class PurgeErrorsCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Purges 404 errors older than the configured threshold, then evicts any exceeding the configured cap.';
+    protected $description = 'Purges 404 errors older than the configured threshold, then purges any exceeding the configured cap.';
 
     /**
      * Execute the console command.
@@ -35,7 +35,7 @@ class PurgeErrorsCommand extends Command
     {
         $this
             ->purgeErrorsOlderThan()
-            ->evictErrorsExceeding();
+            ->purgeErrorsExceeding();
     }
 
     private function purgeErrorsOlderThan(): self
@@ -57,7 +57,7 @@ class PurgeErrorsCommand extends Command
         return $this;
     }
 
-    private function evictErrorsExceeding(): self
+    private function purgeErrorsExceeding(): self
     {
         $maxErrors = config('statamic.seo-pro.redirects.errors.max_errors', 0);
 
@@ -83,10 +83,10 @@ class PurgeErrorsCommand extends Command
                     ->take($excess)
                     ->each->delete();
             },
-            message: 'Evicting excess errors...',
+            message: 'Purging excess errors...',
         );
 
-        $this->components->success("Evicted errors exceeding the cap of $maxErrors.");
+        $this->components->success("Purged errors exceeding the cap of $maxErrors.");
 
         return $this;
     }

--- a/src/Commands/PurgeErrorsCommand.php
+++ b/src/Commands/PurgeErrorsCommand.php
@@ -24,7 +24,7 @@ class PurgeErrorsCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Purges 404 errors older than the configured threshold.';
+    protected $description = 'Purges 404 errors older than the configured threshold, then evicts any exceeding the configured cap.';
 
     /**
      * Execute the console command.
@@ -32,6 +32,13 @@ class PurgeErrorsCommand extends Command
      * @return mixed
      */
     public function handle()
+    {
+        $this
+            ->purgeErrorsOlderThan()
+            ->evictErrorsExceeding();
+    }
+
+    private function purgeErrorsOlderThan(): self
     {
         $threshold = config('statamic.seo-pro.redirects.errors.purge_after_days', 30);
 
@@ -46,5 +53,41 @@ class PurgeErrorsCommand extends Command
         );
 
         $this->components->success("Purged errors older than $threshold days.");
+
+        return $this;
+    }
+
+    private function evictErrorsExceeding(): self
+    {
+        $maxErrors = config('statamic.seo-pro.redirects.errors.max_errors', 0);
+
+        if (! $maxErrors) {
+            return $this;
+        }
+
+        spin(
+            callback: function () use ($maxErrors): void {
+                $errors = Error::query()->get();
+                $excess = $errors->count() - $maxErrors;
+
+                if ($excess <= 0) {
+                    return;
+                }
+
+                $errors
+                    ->sortBy([
+                        fn ($a, $b) => (bool) $a->lastHitAt() <=> (bool) $b->lastHitAt(),
+                        fn ($a, $b) => $a->hits() <=> $b->hits(),
+                        fn ($a, $b) => $a->lastHitAt() <=> $b->lastHitAt(),
+                    ])
+                    ->take($excess)
+                    ->each->delete();
+            },
+            message: 'Evicting excess errors...',
+        );
+
+        $this->components->success("Evicted errors exceeding the cap of $maxErrors.");
+
+        return $this;
     }
 }

--- a/tests/Redirects/Eloquent/PurgeErrorsCommandTest.php
+++ b/tests/Redirects/Eloquent/PurgeErrorsCommandTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Redirects\Eloquent;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\SeoPro\Redirects\Eloquent\ErrorModel;
+use Tests\TestCase;
+
+class PurgeErrorsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('statamic.seo-pro.redirects.errors.driver', 'database');
+    }
+
+    protected function defineDatabaseMigrations()
+    {
+        $this->loadMigrationsFrom(__DIR__.'/../../../src/Commands/stubs');
+    }
+
+    #[Test]
+    public function it_evicts_the_least_valuable_errors_when_max_errors_is_exceeded()
+    {
+        Carbon::setTestNow('2026-04-21 12:00:00');
+
+        config(['statamic.seo-pro.redirects.errors.max_errors' => 2]);
+
+        ErrorModel::create(['site' => 'default', 'url' => '/never-hit', 'hits' => 6, 'last_hit_at' => null, 'data' => []]);
+        ErrorModel::create(['site' => 'default', 'url' => '/rarely-hit', 'hits' => 1, 'last_hit_at' => '2026-04-20 12:00:00', 'data' => []]);
+        ErrorModel::create(['site' => 'default', 'url' => '/stale-popular', 'hits' => 5, 'last_hit_at' => '2026-04-01 12:00:00', 'data' => []]);
+        ErrorModel::create(['site' => 'default', 'url' => '/fresh-popular', 'hits' => 5, 'last_hit_at' => '2026-04-20 12:00:00', 'data' => []]);
+        ErrorModel::create(['site' => 'default', 'url' => '/most-popular', 'hits' => 9, 'last_hit_at' => '2026-04-10 12:00:00', 'data' => []]);
+
+        $this
+            ->artisan('statamic:seo-pro:purge-errors')
+            ->assertSuccessful();
+
+        $this->assertDatabaseMissing('seo_pro_errors', ['url' => '/never-hit']);
+        $this->assertDatabaseMissing('seo_pro_errors', ['url' => '/rarely-hit']);
+        $this->assertDatabaseMissing('seo_pro_errors', ['url' => '/stale-popular']);
+        $this->assertDatabaseHas('seo_pro_errors', ['url' => '/fresh-popular']);
+        $this->assertDatabaseHas('seo_pro_errors', ['url' => '/most-popular']);
+    }
+}

--- a/tests/Redirects/Eloquent/PurgeErrorsCommandTest.php
+++ b/tests/Redirects/Eloquent/PurgeErrorsCommandTest.php
@@ -25,7 +25,7 @@ class PurgeErrorsCommandTest extends TestCase
     }
 
     #[Test]
-    public function it_evicts_the_least_valuable_errors_when_max_errors_is_exceeded()
+    public function it_purges_the_least_valuable_errors_when_max_errors_is_exceeded()
     {
         Carbon::setTestNow('2026-04-21 12:00:00');
 

--- a/tests/Redirects/PurgeErrorsCommandTest.php
+++ b/tests/Redirects/PurgeErrorsCommandTest.php
@@ -97,7 +97,7 @@ class PurgeErrorsCommandTest extends TestCase
     }
 
     #[Test]
-    public function it_evicts_the_least_valuable_errors_when_max_errors_is_exceeded()
+    public function it_purges_the_least_valuable_errors_when_max_errors_is_exceeded()
     {
         Carbon::setTestNow('2026-04-21 12:00:00');
 
@@ -161,7 +161,7 @@ class PurgeErrorsCommandTest extends TestCase
 
     #[Test]
     #[DataProvider('unexceededMaxErrorsProvider')]
-    public function it_does_not_evict_errors_unless_max_errors_is_exceeded($maxErrors)
+    public function it_does_not_purge_errors_unless_max_errors_is_exceeded($maxErrors)
     {
         Carbon::setTestNow('2026-04-21 12:00:00');
 

--- a/tests/Redirects/PurgeErrorsCommandTest.php
+++ b/tests/Redirects/PurgeErrorsCommandTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Redirects;
 
 use Illuminate\Support\Carbon;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\SeoPro\Facades;
 use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
@@ -93,5 +94,125 @@ class PurgeErrorsCommandTest extends TestCase
 
         $this->assertNotNull(Facades\Error::find('recent-one'));
         $this->assertNotNull(Facades\Error::find('recent-two'));
+    }
+
+    #[Test]
+    public function it_evicts_the_least_valuable_errors_when_max_errors_is_exceeded()
+    {
+        Carbon::setTestNow('2026-04-21 12:00:00');
+
+        config(['statamic.seo-pro.redirects.errors.max_errors' => 2]);
+
+        Facades\Error::make()
+            ->id('never-hit')
+            ->url('/never-hit')
+            ->hits(6)
+            ->save();
+
+        $this->createErrorsWithVariedHits();
+
+        $this
+            ->artisan('statamic:seo-pro:purge-errors')
+            ->assertSuccessful();
+
+        $this->assertNull(Facades\Error::find('never-hit'));
+        $this->assertNull(Facades\Error::find('rarely-hit'));
+        $this->assertNull(Facades\Error::find('stale-popular'));
+        $this->assertNotNull(Facades\Error::find('fresh-popular'));
+        $this->assertNotNull(Facades\Error::find('most-popular'));
+    }
+
+    #[Test]
+    public function it_applies_the_age_threshold_before_the_cap()
+    {
+        Carbon::setTestNow('2026-04-21 12:00:00');
+
+        config(['statamic.seo-pro.redirects.errors.max_errors' => 2]);
+
+        Facades\Error::make()
+            ->id('old-error')
+            ->url('/old-page')
+            ->hits(50)
+            ->lastHitAt('2026-03-01 12:00:00')
+            ->save();
+
+        Facades\Error::make()
+            ->id('recent-one')
+            ->url('/page-one')
+            ->hits(1)
+            ->lastHitAt('2026-04-15 12:00:00')
+            ->save();
+
+        Facades\Error::make()
+            ->id('recent-two')
+            ->url('/page-two')
+            ->hits(3)
+            ->lastHitAt('2026-04-20 12:00:00')
+            ->save();
+
+        $this
+            ->artisan('statamic:seo-pro:purge-errors')
+            ->assertSuccessful();
+
+        $this->assertNull(Facades\Error::find('old-error'));
+        $this->assertNotNull(Facades\Error::find('recent-one'));
+        $this->assertNotNull(Facades\Error::find('recent-two'));
+    }
+
+    #[Test]
+    #[DataProvider('unexceededMaxErrorsProvider')]
+    public function it_does_not_evict_errors_unless_max_errors_is_exceeded($maxErrors)
+    {
+        Carbon::setTestNow('2026-04-21 12:00:00');
+
+        config(['statamic.seo-pro.redirects.errors.max_errors' => $maxErrors]);
+
+        $this->createErrorsWithVariedHits();
+
+        $this
+            ->artisan('statamic:seo-pro:purge-errors')
+            ->assertSuccessful();
+
+        $this->assertCount(4, Facades\Error::all());
+    }
+
+    public static function unexceededMaxErrorsProvider(): array
+    {
+        return [
+            'within cap' => [4],
+            'disabled' => [0],
+            'absent' => [null],
+        ];
+    }
+
+    private function createErrorsWithVariedHits(): void
+    {
+        Facades\Error::make()
+            ->id('rarely-hit')
+            ->url('/rarely-hit')
+            ->hits(1)
+            ->lastHitAt('2026-04-20 12:00:00')
+            ->save();
+
+        Facades\Error::make()
+            ->id('stale-popular')
+            ->url('/stale-popular')
+            ->hits(5)
+            ->lastHitAt('2026-04-01 12:00:00')
+            ->save();
+
+        Facades\Error::make()
+            ->id('fresh-popular')
+            ->url('/fresh-popular')
+            ->hits(5)
+            ->lastHitAt('2026-04-20 12:00:00')
+            ->save();
+
+        Facades\Error::make()
+            ->id('most-popular')
+            ->url('/most-popular')
+            ->hits(9)
+            ->lastHitAt('2026-04-10 12:00:00')
+            ->save();
     }
 }


### PR DESCRIPTION
This pull request implements a configurable cap on the number of tracked 404 errors.

On a public site, the error tracker is effectively attacker-writable storage: every bot probe for a unique URL (`/wp-admin`, `/.env`, `/xmlrpc.php`, and endless variations) creates a new error. `purge_after_days` bounds the age of errors but not their count, so between purge runs the data set grows without limit.

This PR adds a `redirects.errors.max_errors` config option, enforced by `seo-pro:purge-errors` after the age purge has run. When the number of errors exceeds the cap, the excess is purged in this order: errors that have never been hit go first, then those with the fewest hits, then those hit least recently. Frequently-hit 404s, the best redirect candidates, survive longest. The default of `0` disables the cap, preserving current behaviour. It works with both the file and database drivers.

```php
// config/statamic/seo-pro.php

'redirects' => [
    'errors' => [
        'max_errors' => 1000,
    ],
],
```

Closes #648
