### PR TITLE
Fix errors with no `last_hit_at` never being purged

### DIFF
--- a/src/Commands/PurgeErrorsCommand.php
+++ b/src/Commands/PurgeErrorsCommand.php
@@ -46,6 +46,7 @@ class PurgeErrorsCommand extends Command
             callback: function () use ($threshold): void {
                 Error::query()
                     ->where('last_hit_at', '<', now()->subDays($threshold))
+                    ->orWhereNull('last_hit_at')
                     ->get()
                     ->each->delete();
             },

--- a/tests/Redirects/Eloquent/PurgeErrorsCommandTest.php
+++ b/tests/Redirects/Eloquent/PurgeErrorsCommandTest.php
@@ -24,6 +24,25 @@ class PurgeErrorsCommandTest extends TestCase
         $this->loadMigrationsFrom(__DIR__.'/../../../src/Commands/stubs');
     }
 
+    /**
+     * @see https://github.com/statamic/seo-pro/issues/647
+     */
+    #[Test]
+    public function it_purges_errors_without_a_last_hit_at()
+    {
+        Carbon::setTestNow('2026-04-21 12:00:00');
+
+        ErrorModel::create(['site' => 'default', 'url' => '/never-hit', 'hits' => 1, 'last_hit_at' => null, 'data' => []]);
+        ErrorModel::create(['site' => 'default', 'url' => '/recent', 'hits' => 1, 'last_hit_at' => '2026-04-20 12:00:00', 'data' => []]);
+
+        $this
+            ->artisan('statamic:seo-pro:purge-errors')
+            ->assertSuccessful();
+
+        $this->assertDatabaseMissing('seo_pro_errors', ['url' => '/never-hit']);
+        $this->assertDatabaseHas('seo_pro_errors', ['url' => '/recent']);
+    }
+
     #[Test]
     public function it_purges_the_least_valuable_errors_when_max_errors_is_exceeded()
     {

--- a/tests/Redirects/PurgeErrorsCommandTest.php
+++ b/tests/Redirects/PurgeErrorsCommandTest.php
@@ -96,6 +96,34 @@ class PurgeErrorsCommandTest extends TestCase
         $this->assertNotNull(Facades\Error::find('recent-two'));
     }
 
+    /**
+     * @see https://github.com/statamic/seo-pro/issues/647
+     */
+    #[Test]
+    public function it_purges_errors_without_a_last_hit_at()
+    {
+        Carbon::setTestNow('2026-04-21 12:00:00');
+
+        Facades\Error::make()
+            ->id('never-hit')
+            ->url('/never-hit-page')
+            ->save();
+
+        Facades\Error::make()
+            ->id('recent')
+            ->url('/recent-page')
+            ->hits(1)
+            ->lastHitAt('2026-04-20 12:00:00')
+            ->save();
+
+        $this
+            ->artisan('statamic:seo-pro:purge-errors')
+            ->assertSuccessful();
+
+        $this->assertNull(Facades\Error::find('never-hit'));
+        $this->assertNotNull(Facades\Error::find('recent'));
+    }
+
     #[Test]
     public function it_purges_the_least_valuable_errors_when_max_errors_is_exceeded()
     {


### PR DESCRIPTION
This pull request fixes an issue where error entries with an empty `last_hit_at` were never purged by the `seo-pro:purge-errors` command.

This was happening because the purge query used `Error::query()->where('last_hit_at', '<', now()->subDays($threshold))`, and errors with no `last_hit_at` never satisfy that comparison, so they were kept forever and accumulated. This only actually bit the database (Eloquent) driver, since SQL never matches `NULL` against `<`. The file (Stache) driver happened to purge them anyway, since PHP's loose comparison treats `null < Carbon` as true.

This PR fixes it by adding `->orWhereNull('last_hit_at')` to the query in `purgeErrorsOlderThan`, so errors without a `last_hit_at` are purged alongside stale ones, on both drivers. Tests were added covering both the Stache and Eloquent drivers.

Fixes #647
