### PR TITLE
Add delete action for tracked 404 errors

### DIFF
--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -12,6 +12,7 @@ return [
     'edit_redirects' => 'Edit Redirects',
     'create_redirects' => 'Create Redirects',
     'delete_redirects' => 'Delete Redirects',
+    'delete_errors' => 'Delete Errors',
     'redirect_source' => 'URL to redirect from. Use `*` as a wildcard, like `/blog/2026/*`.',
     'redirect_destination' => 'URL to redirect to. Use `$1`, `$2`, etc. for wildcard matches.',
     'redirect_response_code' => 'HTTP response code for this redirect.',

--- a/resources/js/pages/errors/Index.vue
+++ b/resources/js/pages/errors/Index.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { Head, Link } from '@statamic/cms/inertia';
-import { Header, Button, Listing, DocsCallout } from '@statamic/cms/ui';
+import { Header, Button, Listing, DropdownItem, DocsCallout } from '@statamic/cms/ui';
 import { ref } from 'vue';
 
 defineProps({
@@ -28,6 +28,7 @@ function requestComplete({ items: newItems, parameters }) {
 	<Listing
 		ref="listing"
 		:url="cp_url(`seo-pro/errors`)"
+		:action-url="cp_url(`seo-pro/errors/actions`)"
 		:columns
 		:allow-presets="false"
 		:allow-customizing-columns="false"
@@ -41,10 +42,13 @@ function requestComplete({ items: newItems, parameters }) {
 		<template #cell-url="{ row: error }">
 			<a class="title-index-field" :href="error.url" target="_blank" rel="noopener noreferrer" v-text="error.url" />
 		</template>
-		<template #cell-actions="{ row: error }">
+		<template #cell-create_redirect="{ row: error }">
 			<div class="flex justify-end">
 				<Button size="xs" icon="moved" :href="error.create_redirect_url" :text="__('seo-pro::messages.create_redirect')" />
 			</div>
+		</template>
+		<template #prepended-row-actions="{ row: error }">
+			<DropdownItem :text="__('seo-pro::messages.create_redirect')" :href="error.create_redirect_url" icon="moved" />
 		</template>
 	</Listing>
 

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -23,7 +23,7 @@ Route::prefix('seo-pro')->name('seo-pro.')->group(function () {
     Route::get('section-defaults/taxonomies/{seo_pro_taxonomy}/edit', [Controllers\CP\TaxonomyDefaultsController::class, 'edit'])->name('section-defaults.taxonomies.edit');
     Route::patch('section-defaults/taxonomies/{seo_pro_taxonomy}', [Controllers\CP\TaxonomyDefaultsController::class, 'update'])->name('section-defaults.taxonomies.update');
 
-    Route::resource('errors', Controllers\CP\ErrorController::class)->only('index');
+    Route::resource('errors', Controllers\CP\Errors\ErrorController::class)->only('index');
 
     Route::get('redirects/export', Controllers\CP\Redirects\ExportRedirectsController::class)->name('redirects.export');
     Route::post('redirects/import', Controllers\CP\Redirects\ImportRedirectsController::class)->name('redirects.import');

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -23,6 +23,8 @@ Route::prefix('seo-pro')->name('seo-pro.')->group(function () {
     Route::get('section-defaults/taxonomies/{seo_pro_taxonomy}/edit', [Controllers\CP\TaxonomyDefaultsController::class, 'edit'])->name('section-defaults.taxonomies.edit');
     Route::patch('section-defaults/taxonomies/{seo_pro_taxonomy}', [Controllers\CP\TaxonomyDefaultsController::class, 'update'])->name('section-defaults.taxonomies.update');
 
+    Route::post('errors/actions', [Controllers\CP\Errors\ErrorActionController::class, 'run'])->name('errors.actions.run');
+    Route::post('errors/actions/list', [Controllers\CP\Errors\ErrorActionController::class, 'bulkActions'])->name('errors.actions.bulk');
     Route::resource('errors', Controllers\CP\Errors\ErrorController::class)->only('index');
 
     Route::get('redirects/export', Controllers\CP\Redirects\ExportRedirectsController::class)->name('redirects.export');

--- a/src/Actions/DeleteError.php
+++ b/src/Actions/DeleteError.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Statamic\SeoPro\Actions;
+
+use Statamic\Actions\Delete;
+use Statamic\SeoPro\Redirects\Error;
+
+class DeleteError extends Delete
+{
+    public function visibleTo($item): bool
+    {
+        return $item instanceof Error;
+    }
+}

--- a/src/Http/Controllers/CP/Errors/ErrorActionController.php
+++ b/src/Http/Controllers/CP/Errors/ErrorActionController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Statamic\SeoPro\Http\Controllers\CP\Errors;
+
+use Illuminate\Support\Collection;
+use Statamic\Http\Controllers\CP\ActionController;
+use Statamic\SeoPro\Facades;
+
+class ErrorActionController extends ActionController
+{
+    protected function getSelectedItems($items, $context): Collection
+    {
+        return $items->map(fn ($id) => Facades\Error::find($id));
+    }
+}

--- a/src/Http/Controllers/CP/Errors/ErrorController.php
+++ b/src/Http/Controllers/CP/Errors/ErrorController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Statamic\SeoPro\Http\Controllers\CP;
+namespace Statamic\SeoPro\Http\Controllers\CP\Errors;
 
 use Inertia\Inertia;
 use Statamic\CP\Column;
@@ -53,7 +53,7 @@ class ErrorController extends CpController
 
         $columns = $blueprint
             ->columns()
-            ->put('actions', Column::make('actions')
+            ->put('create_redirect', Column::make('create_redirect')
                 ->label('')
                 ->listable(true)
                 ->visible(true)

--- a/src/Http/Resources/Redirects/Errors.php
+++ b/src/Http/Resources/Redirects/Errors.php
@@ -33,7 +33,7 @@ class Errors extends ResourceCollection
     {
         $columns = $this->blueprint->columns();
 
-        $actions = Column::make('actions')
+        $createRedirect = Column::make('create_redirect')
             ->label('')
             ->listable(true)
             ->visible(true)
@@ -41,7 +41,7 @@ class Errors extends ResourceCollection
             ->defaultOrder($columns->count() + 1)
             ->sortable(false);
 
-        $columns->put('actions', $actions);
+        $columns->put('create_redirect', $createRedirect);
 
         if ($key = $this->columnPreferenceKey) {
             $columns->setPreferred($key);

--- a/src/Policies/ErrorPolicy.php
+++ b/src/Policies/ErrorPolicy.php
@@ -3,6 +3,7 @@
 namespace Statamic\SeoPro\Policies;
 
 use Statamic\Facades\User;
+use Statamic\SeoPro\Redirects\Error;
 
 class ErrorPolicy
 {
@@ -18,5 +19,10 @@ class ErrorPolicy
     public function index($user): bool
     {
         return User::fromUser($user)->hasPermission('view seo redirects');
+    }
+
+    public function delete($user, Error $error): bool
+    {
+        return User::fromUser($user)->hasPermission('delete seo errors');
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -133,6 +133,7 @@ class ServiceProvider extends AddonServiceProvider
                                 Permission::make('create seo redirects')->label(__('seo-pro::messages.create_redirects')),
                                 Permission::make('delete seo redirects')->label(__('seo-pro::messages.delete_redirects')),
                             ]),
+                        Permission::make('delete seo errors')->label(__('seo-pro::messages.delete_errors')),
                     ]);
             });
             Permission::register('view seo reports', function ($permission) {

--- a/tests/Redirects/DeleteErrorTest.php
+++ b/tests/Redirects/DeleteErrorTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\Redirects;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Role;
+use Statamic\Facades\User;
+use Statamic\SeoPro\Facades;
+use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class DeleteErrorTest extends TestCase
+{
+    use PreventsSavingStacheItemsToDisk;
+
+    #[Test]
+    public function can_delete_selected_errors()
+    {
+        $this->createError('abc', '/broken-link');
+        $this->createError('def', '/another-broken-link');
+        $this->createError('ghi', '/untouched-link');
+
+        $this
+            ->actingAs(User::make()->makeSuper()->save())
+            ->postJson(cp_route('seo-pro.errors.actions.run'), [
+                'action' => 'delete_error',
+                'selections' => ['abc', 'def'],
+                'values' => [],
+            ])
+            ->assertOk()
+            ->assertJson(['success' => true]);
+
+        $this->assertNull(Facades\Error::find('abc'));
+        $this->assertNull(Facades\Error::find('def'));
+        $this->assertNotNull(Facades\Error::find('ghi'));
+    }
+
+    #[Test]
+    public function delete_action_is_listed_for_selected_errors()
+    {
+        $this->createError('abc', '/broken-link');
+        $this->createError('def', '/another-broken-link');
+
+        $this
+            ->actingAs(User::make()->makeSuper()->save())
+            ->postJson(cp_route('seo-pro.errors.actions.bulk'), [
+                'selections' => ['abc', 'def'],
+            ])
+            ->assertOk()
+            ->assertJsonCount(1)
+            ->assertJsonPath('0.handle', 'delete_error');
+    }
+
+    #[Test]
+    public function cant_delete_selected_errors_without_permission()
+    {
+        $this->createError('abc', '/broken-link');
+        $this->createError('def', '/another-broken-link');
+
+        Role::make('test')->addPermission('access cp')->addPermission('view seo redirects')->save();
+
+        $this
+            ->actingAs(User::make()->assignRole('test')->save())
+            ->postJson(cp_route('seo-pro.errors.actions.run'), [
+                'action' => 'delete_error',
+                'selections' => ['abc', 'def'],
+                'values' => [],
+            ])
+            ->assertForbidden();
+
+        $this->assertNotNull(Facades\Error::find('abc'));
+        $this->assertNotNull(Facades\Error::find('def'));
+    }
+
+    #[Test]
+    public function delete_action_is_not_listed_without_permission()
+    {
+        $this->createError('abc', '/broken-link');
+        $this->createError('def', '/another-broken-link');
+
+        Role::make('test')->addPermission('access cp')->addPermission('view seo redirects')->save();
+
+        $this
+            ->actingAs(User::make()->assignRole('test')->save())
+            ->postJson(cp_route('seo-pro.errors.actions.bulk'), [
+                'selections' => ['abc', 'def'],
+            ])
+            ->assertOk()
+            ->assertJsonCount(0);
+    }
+
+    private function createError(string $id, string $url): void
+    {
+        Facades\Error::make()
+            ->id($id)
+            ->url($url)
+            ->hits(1)
+            ->lastHitAt('2026-04-21 12:00:00')
+            ->save();
+    }
+}


### PR DESCRIPTION
This pull request implements delete actions for tracked 404 errors. Until now the errors listing was read-only, so the only way to clear out bot noise and junk URLs was to wait for `purge_after_days` to catch up.

Errors can now be deleted individually from the row's actions dropdown, or in bulk by selecting rows in the listing. Both go through a new `DeleteError` action, which extends Statamic's core `Delete` action and is served by an `ErrorActionController`, so the listing gets the native bulk actions toolbar for free.

Deleting is gated by a new `delete seo errors` permission, nested under "View Redirects" in the SEO Pro permission group.

This PR also moves `ErrorController` into an `Errors` namespace to match the existing `Redirects` controllers.

This PR does not add CP-configurable retention, which was also requested in the issue. Retention stays in the config file via `purge_after_days` (and the cap being added in #654).

---

Closes #649
Related: #654
