### PR TITLE
Add delete action for redirects

### DIFF
--- a/resources/js/pages/redirects/Index.vue
+++ b/resources/js/pages/redirects/Index.vue
@@ -45,6 +45,7 @@ function requestComplete({ items: newItems, parameters }) {
 	<Listing
 		ref="listing"
 		:url="cp_url(`seo-pro/redirects`)"
+		:action-url="cp_url(`seo-pro/redirects/actions`)"
 		:columns
 		:allow-presets="false"
 		sort-column="source"
@@ -63,26 +64,12 @@ function requestComplete({ items: newItems, parameters }) {
 				<StatusIndicator v-if="!isColumnVisible('status')" :status="redirect.status" />
 				<span v-text="redirect.source" />
 			</span>
-
-			<resource-deleter
-				v-if="redirect.deletable"
-				:ref="`deleter_${redirect.id}`"
-				:resource="redirect"
-				@deleted="listing.refresh()"
-			/>
 		</template>
 		<template #cell-status="{ row: redirect }">
 			<StatusIndicator :status="redirect.status" show-label :show-dot="false" />
 		</template>
 		<template #prepended-row-actions="{ row: redirect }">
 			<DropdownItem v-if="redirect.editable" :text="__('Edit')" :href="redirect.edit_url" icon="edit" />
-			<DropdownItem
-				v-if="redirect.deletable"
-				:text="__('Delete')"
-				icon="trash"
-				variant="destructive"
-				@click="$refs[`deleter_${redirect.id}`].confirm()"
-			/>
 		</template>
 	</Listing>
 

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -29,7 +29,9 @@ Route::prefix('seo-pro')->name('seo-pro.')->group(function () {
 
     Route::get('redirects/export', Controllers\CP\Redirects\ExportRedirectsController::class)->name('redirects.export');
     Route::post('redirects/import', Controllers\CP\Redirects\ImportRedirectsController::class)->name('redirects.import');
-    Route::resource('redirects', Controllers\CP\Redirects\RedirectController::class)->except('show');
+    Route::post('redirects/actions', [Controllers\CP\Redirects\RedirectActionController::class, 'run'])->name('redirects.actions.run');
+    Route::post('redirects/actions/list', [Controllers\CP\Redirects\RedirectActionController::class, 'bulkActions'])->name('redirects.actions.bulk');
+    Route::resource('redirects', Controllers\CP\Redirects\RedirectController::class)->except('show', 'destroy');
 
     Route::post('preview', Controllers\CP\PreviewController::class)->name('preview');
 });

--- a/src/Actions/DeleteRedirect.php
+++ b/src/Actions/DeleteRedirect.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Statamic\SeoPro\Actions;
+
+use Statamic\Actions\Delete;
+use Statamic\SeoPro\Redirects\Redirect;
+
+class DeleteRedirect extends Delete
+{
+    public function visibleTo($item): bool
+    {
+        return $item instanceof Redirect;
+    }
+}

--- a/src/Http/Controllers/CP/Redirects/RedirectActionController.php
+++ b/src/Http/Controllers/CP/Redirects/RedirectActionController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Statamic\SeoPro\Http\Controllers\CP\Redirects;
+
+use Illuminate\Support\Collection;
+use Statamic\Http\Controllers\CP\ActionController;
+use Statamic\SeoPro\Facades;
+
+class RedirectActionController extends ActionController
+{
+    protected function getSelectedItems($items, $context): Collection
+    {
+        return $items->map(fn ($id) => Facades\Redirect::find($id));
+    }
+}

--- a/src/Http/Controllers/CP/Redirects/RedirectController.php
+++ b/src/Http/Controllers/CP/Redirects/RedirectController.php
@@ -193,11 +193,4 @@ class RedirectController extends CpController
 
         $redirect->save();
     }
-
-    public function destroy(Request $request, Redirect $redirect)
-    {
-        $this->authorize('delete', $redirect);
-
-        $redirect->delete();
-    }
 }

--- a/src/Http/Resources/Redirects/ListedRedirect.php
+++ b/src/Http/Resources/Redirects/ListedRedirect.php
@@ -42,9 +42,7 @@ class ListedRedirect extends JsonResource
             ])),
 
             'edit_url' => $redirect->editUrl(),
-            'delete_url' => $redirect->deleteUrl(),
             'editable' => User::current()->can('edit', $redirect),
-            'deletable' => User::current()->can('delete', $redirect),
         ];
     }
 

--- a/src/Redirects/Redirect.php
+++ b/src/Redirects/Redirect.php
@@ -177,11 +177,6 @@ class Redirect
         return cp_route('seo-pro.redirects.update', $this->id());
     }
 
-    public function deleteUrl(): string
-    {
-        return cp_route('seo-pro.redirects.destroy', $this->id());
-    }
-
     public function getQueryableValue(string $field)
     {
         if (in_array($method = Str::camel($field), $this->queryableMethods())) {

--- a/tests/Redirects/DeleteRedirectTest.php
+++ b/tests/Redirects/DeleteRedirectTest.php
@@ -14,44 +14,89 @@ class DeleteRedirectTest extends TestCase
     use PreventsSavingStacheItemsToDisk;
 
     #[Test]
-    public function can_delete_redirect()
+    public function can_delete_selected_redirects()
     {
-        Facades\Redirect::make()
-            ->id('abc')
-            ->source('https://cool-runnings.com/old-url')
-            ->destination('https://cool-runnings.com/new-url')
-            ->responseCode(302)
-            ->enabled(true)
-            ->save();
-
-        $this->assertNotNull(Facades\Redirect::find('abc'));
+        $this->createRedirect('abc', '/old-url');
+        $this->createRedirect('def', '/another-old-url');
+        $this->createRedirect('ghi', '/untouched-url');
 
         $this
             ->actingAs(User::make()->makeSuper()->save())
-            ->delete(cp_route('seo-pro.redirects.destroy', 'abc'))
-            ->assertOk();
+            ->postJson(cp_route('seo-pro.redirects.actions.run'), [
+                'action' => 'delete_redirect',
+                'selections' => ['abc', 'def'],
+                'values' => [],
+            ])
+            ->assertOk()
+            ->assertJson(['success' => true]);
 
         $this->assertNull(Facades\Redirect::find('abc'));
+        $this->assertNull(Facades\Redirect::find('def'));
+        $this->assertNotNull(Facades\Redirect::find('ghi'));
     }
 
     #[Test]
-    public function cant_delete_redirect_without_permission()
+    public function delete_action_is_listed_for_selected_redirects()
     {
-        Facades\Redirect::make()
-            ->id('abc')
-            ->source('https://cool-runnings.com/old-url')
-            ->destination('https://cool-runnings.com/new-url')
-            ->responseCode(302)
-            ->enabled(true)
-            ->save();
+        $this->createRedirect('abc', '/old-url');
+        $this->createRedirect('def', '/another-old-url');
 
-        Role::make('test')->addPermission('access cp')->save();
+        $this
+            ->actingAs(User::make()->makeSuper()->save())
+            ->postJson(cp_route('seo-pro.redirects.actions.bulk'), [
+                'selections' => ['abc', 'def'],
+            ])
+            ->assertOk()
+            ->assertJsonCount(1)
+            ->assertJsonPath('0.handle', 'delete_redirect');
+    }
+
+    #[Test]
+    public function cant_delete_selected_redirects_without_permission()
+    {
+        $this->createRedirect('abc', '/old-url');
+        $this->createRedirect('def', '/another-old-url');
+
+        Role::make('test')->addPermission('access cp')->addPermission('view seo redirects')->save();
 
         $this
             ->actingAs(User::make()->assignRole('test')->save())
-            ->delete(cp_route('seo-pro.redirects.destroy', 'abc'))
-            ->assertRedirect('/cp');
+            ->postJson(cp_route('seo-pro.redirects.actions.run'), [
+                'action' => 'delete_redirect',
+                'selections' => ['abc', 'def'],
+                'values' => [],
+            ])
+            ->assertForbidden();
 
         $this->assertNotNull(Facades\Redirect::find('abc'));
+        $this->assertNotNull(Facades\Redirect::find('def'));
+    }
+
+    #[Test]
+    public function delete_action_is_not_listed_without_permission()
+    {
+        $this->createRedirect('abc', '/old-url');
+        $this->createRedirect('def', '/another-old-url');
+
+        Role::make('test')->addPermission('access cp')->addPermission('view seo redirects')->save();
+
+        $this
+            ->actingAs(User::make()->assignRole('test')->save())
+            ->postJson(cp_route('seo-pro.redirects.actions.bulk'), [
+                'selections' => ['abc', 'def'],
+            ])
+            ->assertOk()
+            ->assertJsonCount(0);
+    }
+
+    private function createRedirect(string $id, string $source): void
+    {
+        Facades\Redirect::make()
+            ->id($id)
+            ->source($source)
+            ->destination('/new-url')
+            ->responseCode(302)
+            ->enabled(true)
+            ->save();
     }
 }


### PR DESCRIPTION
This pull request refactors redirect deletion to go through a `DeleteRedirect` action, matching how tracked 404 errors are deleted in #656.

This PR removes the `destroy` route and the `resource-deleter` component from the redirects listing. Redirects can now be deleted from the row actions dropdown or in bulk via the listing's action bar.

Related: #656